### PR TITLE
Make path a string for comparison

### DIFF
--- a/lib/bootsnap/load_path_cache/path.rb
+++ b/lib/bootsnap/load_path_cache/path.rb
@@ -79,7 +79,7 @@ module Bootsnap
 
       def stability
         @stability ||= begin
-          if Gem.path.detect { |p| path.start_with?(p) }
+          if Gem.path.detect { |p| path.to_s.start_with?(p) }
             STABLE
           elsif path.start_with?(RUBY_PREFIX)
             STABLE


### PR DESCRIPTION
```shell
/Users/juliannadeau/.gem/ruby/2.3.3/gems/bootsnap-0.2.4/lib/bootsnap/load_path_cache/path.rb:82:in `block in stability': undefined method `start_with?' for #<Pathname:0x007fee5c2dfe90> (NoMethodError)
	from /Users/juliannadeau/.gem/ruby/2.3.3/gems/bootsnap-0.2.4/lib/bootsnap/load_path_cache/path.rb:82:in `each'
	from /Users/juliannadeau/.gem/ruby/2.3.3/gems/bootsnap-0.2.4/lib/bootsnap/load_path_cache/path.rb:82:in `detect'
	from /Users/juliannadeau/.gem/ruby/2.3.3/gems/bootsnap-0.2.4/lib/bootsnap/load_path_cache/path.rb:82:in `stability'
	from /Users/juliannadeau/.gem/ruby/2.3.3/gems/bootsnap-0.2.4/lib/bootsnap/load_path_cache/path.rb:10:in `stable?'
	from /Users/juliannadeau/.gem/ruby/2.3.3/gems/bootsnap-0.2.4/lib/bootsnap/load_path_cache/path.rb:29:in `entries_and_dirs'
	from /Users/juliannadeau/.gem/ruby/2.3.3/gems/bootsnap-0.2.4/lib/bootsnap/load_path_cache/cache.rb:104:in `block (2 levels) in push_paths_locked'
	from /Users/juliannadeau/.gem/ruby/2.3.3/gems/bootsnap-0.2.4/lib/bootsnap/load_path_cache/cache.rb:102:in `each'
	from /Users/juliannadeau/.gem/ruby/2.3.3/gems/bootsnap-0.2.4/lib/bootsnap/load_path_cache/cache.rb:102:in `block in push_paths_locked'
	from /Users/juliannadeau/.gem/ruby/2.3.3/gems/bootsnap-0.2.4/lib/bootsnap/load_path_cache/store.rb:44:in `transaction'
	from /Users/juliannadeau/.gem/ruby/2.3.3/gems/bootsnap-0.2.4/lib/bootsnap/load_path_cache/cache.rb:101:in `push_paths_locked'
	from /Users/juliannadeau/.gem/ruby/2.3.3/gems/bootsnap-0.2.4/lib/bootsnap/load_path_cache/cache.rb:94:in `block in reinitialize'
	from /Users/juliannadeau/.gem/ruby/2.3.3/gems/bootsnap-0.2.4/lib/bootsnap/load_path_cache/cache.rb:88:in `synchronize'
	from /Users/juliannadeau/.gem/ruby/2.3.3/gems/bootsnap-0.2.4/lib/bootsnap/load_path_cache/cache.rb:88:in `reinitialize'
	from /Users/juliannadeau/.gem/ruby/2.3.3/gems/bootsnap-0.2.4/lib/bootsnap/load_path_cache/cache.rb:28:in `find'
	from /Users/juliannadeau/.gem/ruby/2.3.3/gems/bootsnap-0.2.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:16:in `require'
	from /Users/juliannadeau/.gem/ruby/2.3.3/gems/activesupport-5.1.0.rc1/lib/active_support/dependencies.rb:292:in `block in require'
	from /Users/juliannadeau/.gem/ruby/2.3.3/gems/activesupport-5.1.0.rc1/lib/active_support/dependencies.rb:258:in `load_dependency'
	from /Users/juliannadeau/.gem/ruby/2.3.3/gems/activesupport-5.1.0.rc1/lib/active_support/dependencies.rb:292:in `require'
	from /Users/juliannadeau/.gem/ruby/2.3.3/gems/activerecord-5.1.0.rc1/lib/active_record/connection_adapters/connection_specification.rb:186:in `spec'
	from /Users/juliannadeau/.gem/ruby/2.3.3/gems/activerecord-5.1.0.rc1/lib/active_record/connection_adapters/abstract