### PR TITLE
Fix crash on missing method start_with? on path object

### DIFF
--- a/lib/bootsnap/load_path_cache/path.rb
+++ b/lib/bootsnap/load_path_cache/path.rb
@@ -20,7 +20,7 @@ module Bootsnap
       attr_reader :path
 
       def initialize(path)
-        @path = path
+        @path = path.to_s
       end
 
       # Return a list of all the requirable files and all of the subdirectories
@@ -79,9 +79,9 @@ module Bootsnap
 
       def stability
         @stability ||= begin
-          if Gem.path.detect { |p| path.to_s.start_with?(p) }
+          if Gem.path.detect { |p| path.start_with?(p.to_s) }
             STABLE
-          elsif path.to_s.start_with?(RUBY_PREFIX)
+          elsif path.start_with?(RUBY_PREFIX)
             STABLE
           else
             VOLATILE

--- a/lib/bootsnap/load_path_cache/path.rb
+++ b/lib/bootsnap/load_path_cache/path.rb
@@ -81,7 +81,7 @@ module Bootsnap
         @stability ||= begin
           if Gem.path.detect { |p| path.to_s.start_with?(p) }
             STABLE
-          elsif path.start_with?(RUBY_PREFIX)
+          elsif path.to_s.start_with?(RUBY_PREFIX)
             STABLE
           else
             VOLATILE

--- a/lib/bootsnap/load_path_cache/path_scanner.rb
+++ b/lib/bootsnap/load_path_cache/path_scanner.rb
@@ -12,7 +12,8 @@ module Bootsnap
       BUNDLE_PATH = (Bundler.bundle_path.cleanpath.to_s << LoadPathCache::SLASH).freeze
 
       def self.call(path)
-        raise RelativePathNotSupported unless path.to_s.start_with?(SLASH)
+        path = path.to_s
+        raise RelativePathNotSupported unless path.start_with?(SLASH)
 
         relative_slice = (path.size + 1)..-1
         # If the bundle path is a descendent of this path, we do additional

--- a/lib/bootsnap/load_path_cache/path_scanner.rb
+++ b/lib/bootsnap/load_path_cache/path_scanner.rb
@@ -12,7 +12,7 @@ module Bootsnap
       BUNDLE_PATH = (Bundler.bundle_path.cleanpath.to_s << LoadPathCache::SLASH).freeze
 
       def self.call(path)
-        raise RelativePathNotSupported unless path.start_with?(SLASH)
+        raise RelativePathNotSupported unless path.to_s.start_with?(SLASH)
 
         relative_slice = (path.size + 1)..-1
         # If the bundle path is a descendent of this path, we do additional


### PR DESCRIPTION
Follow up of #9 

```ruby
/Users/piorbastida/.gem/ruby/2.3.3/bundler/gems/bootsnap-1428f0b5ad81/lib/bootsnap/load_path_cache/path.rb:84:in `stability': undefined method `start_with?' for #<Pathname:0x007fb5e91cce28> (NoMethodError)
	from /Users/piorbastida/.gem/ruby/2.3.3/bundler/gems/bootsnap-1428f0b5ad81/lib/bootsnap/load_path_cache/path.rb:10:in `stable?'
	from /Users/piorbastida/.gem/ruby/2.3.3/bundler/gems/bootsnap-1428f0b5ad81/lib/bootsnap/load_path_cache/path.rb:29:in `entries_and_dirs'
	from /Users/piorbastida/.gem/ruby/2.3.3/bundler/gems/bootsnap-1428f0b5ad81/lib/bootsnap/load_path_cache/cache.rb:104:in `block (2 levels) in push_paths_locked'
	from /Users/piorbastida/.gem/ruby/2.3.3/bundler/gems/bootsnap-1428f0b5ad81/lib/bootsnap/load_path_cache/cache.rb:102:in `each'
	from /Users/piorbastida/.gem/ruby/2.3.3/bundler/gems/bootsnap-1428f0b5ad81/lib/bootsnap/load_path_cache/cache.rb:102:in `block in push_paths_locked'
	from /Users/piorbastida/.gem/ruby/2.3.3/bundler/gems/bootsnap-1428f0b5ad81/lib/bootsnap/load_path_cache/store.rb:44:in `transaction'
	from /Users/piorbastida/.gem/ruby/2.3.3/bundler/gems/bootsnap-1428f0b5ad81/lib/bootsnap/load_path_cache/cache.rb:101:in `push_paths_locked'
	from /Users/piorbastida/.gem/ruby/2.3.3/bundler/gems/bootsnap-1428f0b5ad81/lib/bootsnap/load_path_cache/cache.rb:94:in `block in reinitialize'
	from /Users/piorbastida/.gem/ruby/2.3.3/bundler/gems/bootsnap-1428f0b5ad81/lib/bootsnap/load_path_cache/cache.rb:88:in `synchronize'
	from /Users/piorbastida/.gem/ruby/2.3.3/bundler/gems/bootsnap-1428f0b5ad81/lib/bootsnap/load_path_cache/cache.rb:88:in `reinitialize'
	from /Users/piorbastida/.gem/ruby/2.3.3/bundler/gems/bootsnap-1428f0b5ad81/lib/bootsnap/load_path_cache/cache.rb:28:in `find'
	from /Users/piorbastida/.gem/ruby/2.3.3/bundler/gems/bootsnap-1428f0b5ad81/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:16:in `require'
	from /Users/piorbastida/.gem/ruby/2.3.3/gems/activesupport-5.1.0.rc1/lib/active_support/dependencies.rb:292:in `block in require'
	from /Users/piorbastida/.gem/ruby/2.3.3/gems/activesupport-5.1.0.rc1/lib/active_support/dependencies.rb:258:in `load_dependency'
	from /Users/piorbastida/.gem/ruby/2.3.3/gems/activesupport-5.1.0.rc1/lib/active_support/dependencies.rb:292:in `require'
	from /Users/piorbastida/.gem/ruby/2.3.3/gems/activerecord-5.1.0.rc1/lib/active_record/connection_adapters/connection_specification.rb:186:in `spec'
	from /Users/piorbastida/.gem/ruby/2.3.3/gems/activerecord-5.1.0.rc1/lib/active_record/connection_adapters/abstract/connection_pool.rb:878:in `establish_connection'
	from /Users/piorbastida/.gem/ruby/2.3.3/gems/activerecord-5.1.0.rc1/lib/active_record/connection_handling.rb:58:in `establish_connection'
	from /Users/piorbastida/.gem/ruby/2.3.3/gems/spring-2.0.0/lib/spring/application.rb:267:in `connect_database'
	from /Users/piorbastida/.gem/ruby/2.3.3/gems/spring-2.0.0/lib/spring/application.rb:148:in `serve'
	from /Users/piorbastida/.gem/ruby/2.3.3/gems/spring-2.0.0/lib/spring/application.rb:131:in `block in run'
	from /Users/piorbastida/.gem/ruby/2.3.3/gems/spring-2.0.0/lib/spring/application.rb:125:in `loop'
	from /Users/piorbastida/.gem/ruby/2.3.3/gems/spring-2.0.0/lib/spring/application.rb:125:in `run'
	from /Users/piorbastida/.gem/ruby/2.3.3/gems/spring-2.0.0/lib/spring/application/boot.rb:19:in `<top (required)>'
	from /opt/rubies/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /opt/rubies/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from -e:1:in `<main>'
```

@burke 