### PR TITLE
FEATURE: stop using xattr binary to set/remove xattrs

### DIFF
--- a/bootsnap.gemspec
+++ b/bootsnap.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake-compiler', '~> 0'
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "mocha", "~> 1.2"
+  spec.add_development_dependency "ffi-xattr", "~> 0.1.2"
 
   spec.add_runtime_dependency "msgpack", "~> 1.0"
   spec.add_runtime_dependency "snappy", "~> 0.0.15"

--- a/test/compile_cache_key_format_test.rb
+++ b/test/compile_cache_key_format_test.rb
@@ -84,7 +84,8 @@ class CompileCacheKeyFormatTest < Minitest::Test
   end
 
   def get_attr(name, path)
-    loadhex(`xattr -p #{name} #{path}`.chomp)
+    xattr = Xattr.new(path)
+    xattr[name]
   end
 
   def loadhex(str)

--- a/test/compile_cache_test.rb
+++ b/test/compile_cache_test.rb
@@ -85,7 +85,8 @@ class CompileCacheTest < Minitest::Test
     Bootsnap::CompileCache::ISeq.expects(:input_to_storage).times(2).returns(storage)
     Bootsnap::CompileCache::ISeq.expects(:storage_to_output).times(2).returns(output)
     load(path)
-    `xattr -d user.aotcc.value #{path}`
+    xattr = Xattr.new(path)
+    xattr.remove('user.aotcc.value')
     load(path)
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,7 @@ require 'bootsnap'
 
 require 'tmpdir'
 require 'fileutils'
+require 'ffi-xattr'
 
 require 'minitest/autorun'
 require 'mocha/mini_test'


### PR DESCRIPTION
Using ffi-xattr has better compatibility with Linux 