### PR TITLE
ignore relative paths added to $LOAD_PATH

### DIFF
--- a/lib/bootsnap/load_path_cache/cache.rb
+++ b/lib/bootsnap/load_path_cache/cache.rb
@@ -121,7 +121,11 @@ module Bootsnap
           paths.map(&:to_s).each do |path|
             p = Path.new(path)
             next if p.non_directory?
-            entries, dirs = p.entries_and_dirs(@store)
+            begin
+              entries, dirs = p.entries_and_dirs(@store)
+            rescue PathScanner::RelativePathNotSupported
+              next
+            end
             # push -> low precedence -> set only if unset
             dirs.each    { |dir| @dirs[dir]  ||= true }
             entries.each { |rel| @index[rel] ||= path }
@@ -134,7 +138,11 @@ module Bootsnap
           paths.map(&:to_s).reverse.each do |path|
             p = Path.new(path)
             next if p.non_directory?
-            entries, dirs = p.entries_and_dirs(@store)
+            begin
+              entries, dirs = p.entries_and_dirs(@store)
+            rescue PathScanner::RelativePathNotSupported
+              next
+            end
             # unshift -> high precedence -> unconditional set
             dirs.each    { |dir| @dirs[dir]  = true }
             entries.each { |rel| @index[rel] = path }


### PR DESCRIPTION
This PR rescues the `RelativePathNotSupported` error when a relative path is added to the `$LOAD_PATH`.

The use case is an application including the `cucumber` gem, which has [code](https://github.com/cucumber/cucumber-ruby/blob/master/lib/cucumber/load_path.rb#L14) that unshifts a relative path `lib` onto `$LOAD_PATH`.

The desired behavior would be to just skip caching files loaded via a relative load path, rather than raising an error that exits the application. There are likely some side-effects from this change (I don't understand the load-path caching code very well) so please let me know if this workaround is misguided for some reason.