### PR TITLE
FIX: silently recover from cache corruption

### DIFF
--- a/lib/bootsnap/load_path_cache/store.rb
+++ b/lib/bootsnap/load_path_cache/store.rb
@@ -58,7 +58,8 @@ module Bootsnap
       def load_data
         @data = begin
           MessagePack.load(File.binread(@store_path))
-        rescue Errno::ENOENT, MessagePack::MalformedFormatError
+        # handle malformed data due to upgrade incompatability
+        rescue Errno::ENOENT, MessagePack::MalformedFormatError, MessagePack::UnknownExtTypeError
           {}
         end
       end


### PR DESCRIPTION
cache could be corrupted due to libsnappy removal, this will silently recover from another case of malformed message pack data. 