### PR TITLE
support for active support 3

### DIFF
--- a/lib/bootsnap/load_path_cache/core_ext/active_support.rb
+++ b/lib/bootsnap/load_path_cache/core_ext/active_support.rb
@@ -50,8 +50,14 @@ module Bootsnap
             CoreExt::ActiveSupport.with_bootsnap_fallback(NameError) { super }
           end
 
-          def depend_on(file_name, message = "No such file to load -- %s.rb")
-            CoreExt::ActiveSupport.with_bootsnap_fallback(LoadError) { super }
+          if ::ActiveSupport::VERSION::MAJOR > 3
+            def depend_on(file_name, message = "No such file to load -- %s.rb")
+              CoreExt::ActiveSupport.with_bootsnap_fallback(LoadError) { super }
+            end
+          else
+            def depend_on(file_name, swallow_load_errors = false, message = "No such file to load -- %s.rb")
+              CoreExt::ActiveSupport.with_bootsnap_fallback(LoadError) { super }
+            end
           end
         end
       end


### PR DESCRIPTION
In ActiveSupport 3.2 api for `depend_on` is different
https://github.com/rails/rails/blob/3-2-stable/activesupport/lib/active_support/dependencies.rb#L311
vs
https://github.com/rails/rails/blob/4-0-stable/activesupport/lib/active_support/dependencies.rb#L287