### PR TITLE
add Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+os: osx
+language: ruby
+rvm: ruby-2.4.0
+before_script: rake
+script: bin/testunit


### PR DESCRIPTION
Running automated tests via continuous integration helps clearly define a set of known-working environments and makes an open-project much more stable, particularly in this case where there's a C extension with some platform-specific bits involved.

I set up a Travis CI config because that service supports OSX-platform builds in its free tier, which is this project's first known-working environment.

According to the [CI build](https://travis-ci.org/wjordan/bootsnap/builds/234664031) there's already been a regression in one test- I will submit a fix in a separate PR.