### PR TITLE
fix test_no_write_permission

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+os: osx
+language: ruby
+rvm: ruby-2.4.0
+before_script: rake
+script: bin/testunit

--- a/test/compile_cache_test.rb
+++ b/test/compile_cache_test.rb
@@ -9,6 +9,7 @@ class CompileCacheTest < Minitest::Test
   end
 
   def test_no_write_permission
+    ENV['OPT_AOT_LOG'] = '1'
     path = set_file('a.rb', 'a = 3', 100)
     FileUtils.chmod(0400, path)
     Bootsnap::CompileCache::ISeq.expects(:input_to_storage).never


### PR DESCRIPTION
Fixes `test_no_write_permission` unit test, by setting the `OPT_AOT_LOG` environment variable in the test (see passing [Travis CI build](https://travis-ci.org/wjordan/bootsnap/builds/234666264)).

Currently depends on Travis CI config (see separate PR #38), though that commit can be removed if desired.