### PR TITLE
Add a message to relative path error

### DIFF
--- a/lib/bootsnap/load_path_cache/path_scanner.rb
+++ b/lib/bootsnap/load_path_cache/path_scanner.rb
@@ -13,7 +13,9 @@ module Bootsnap
 
       def self.call(path)
         path = path.to_s
-        raise RelativePathNotSupported unless path.start_with?(SLASH)
+        unless path.start_with?(SLASH)
+          raise RelativePathNotSupported, "Bootsnap can not cache relative load paths: '#{path}'"
+        end
 
         relative_slice = (path.size + 1)..-1
         # If the bundle path is a descendent of this path, we do additional


### PR DESCRIPTION
Setting up bootsnap on a project that uses Cucumber, I ran across the same issue described in https://github.com/Shopify/bootsnap/pull/26. Cucumber adds a relative `lib` load path, which bootsnap does not support.

I thought it would make debugging easier if the error message for `RelativePathNotSupported` included the offending path.

As a user, you are most likely to encounter this error when setting up bootsnap for the first time on an existing project. This message immediately tells you what to start grepping for to resolve the issue. :)
