### PR TITLE
Open cache file as read-only

### DIFF
--- a/ext/bootsnap/bootsnap.c
+++ b/ext/bootsnap/bootsnap.c
@@ -316,7 +316,7 @@ open_cache_file(const char * path, struct bs_cache_key * key)
 {
   int fd, res;
 
-  fd = open(path, O_RDWR, 0644);
+  fd = open(path, O_RDONLY);
   if (fd < 0) {
     if (errno == ENOENT) return CACHE_MISSING_OR_INVALID;
     return ERROR_WITH_ERRNO;

--- a/test/compile_cache_test.rb
+++ b/test/compile_cache_test.rb
@@ -5,11 +5,19 @@ class CompileCacheTest < Minitest::Test
 
   def test_no_write_permission_to_cache
     path = Help.set_file('a.rb', 'a = 3', 100)
-    cp = Help.cache_path(@tmp_dir, path)
-    FileUtils.mkdir_p(File.dirname(cp))
-    FileUtils.touch(cp)
-    FileUtils.chmod(0400, cp)
+    folder = File.dirname(Help.cache_path(@tmp_dir, path))
+    FileUtils.mkdir_p(folder)
+    FileUtils.chmod(0400, folder)
     assert_raises(Errno::EACCES) { load(path) }
+  end
+
+  def test_can_open_read_only_cache
+    path = Help.set_file('a.rb', 'a = 3', 100)
+    # Load once to create the cache file
+    load(path)
+    FileUtils.chmod(0400, path)
+    # Loading again after the file is marked read-only should still succeed
+    load(path)
   end
 
   def test_file_is_only_read_once


### PR DESCRIPTION
## Summary
When opening a previously generated cache file, we will now open the file as read-only. Consumers of this method never wrote to the file descriptor and opening as read-only enables us to avoid needing write permissions on the cache folder.

## Details
I'm experimenting with using bootsnap+Docker, to pre-compile the bootsnap cache at build-time, then ship the cache with the container image. In general, these containers will all be write-restricted so the Rails application only has permissions to write to a handful of files/folders. This is because I want to strictly enforce that no code changes after it's been deployed to production, both for security and to ensure that all hosts are exactly uniform (running code can't deviate between machines).

Based on the commit that last changed this file, I feel this was an oversight because ```open_current_file``` also opens a file, but it correctly uses ```O_RDONLY```.

### Before
```
# strace -F su www-data -s/bin/sh -c "RAILS_ENV=production rake -T"
[...]
[pid    16] open("tmp/cache/bootsnap-compile-cache/49/30782f36657865", O_RDWR) = -1 EACCES (Permission denied)
```

### After
```
# strace -F su www-data -s/bin/sh -c "RAILS_ENV=production rake -T"
[...]
[pid    29] open("tmp/cache/bootsnap-compile-cache/49/30782f36657865", O_RDONLY) = 10
```

## Testing done
I've run this change with a simple Docker container that built where the tmp/cache/bootsnap-compile-cache is marked as read-only. I've added a new unit test for this situation and had to fix an existing unit test. The existing test case didn't really match the new pattern since it was only marking the file as read-only, but the parent folder was still read-write. The rename syscall seems to follow the parent folder permissions. Basically it would EACCES from the original open syscall since it couldn't get write permissions, but it didn't really need them at that point. Instead it only needed write permissions when it went to update the cache file.

Please let me know if I'm missing any subtle interactions here, but through my reading of the code and the previous commits, this function doesn't actually need to return a read/write fd.