### PR TITLE
implement bootsnap/setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,15 @@ Add `bootsnap` to your `Gemfile`:
 gem 'bootsnap'
 ```
 
-Next, add this to your boot setup immediately after `require 'bundler/setup'` (i.e. as early as
-possible: the sooner this is loaded, the sooner it can start optimizing things)
+If you are using rails, add this to `config/boot.rb` immediately after `require 'bundler/setup'`:
+
+```ruby
+require 'bootsnap/setup'
+```
+
+If you are not using rails, or if you are but want more control over things, add this to your
+application setup immediately after `require 'bundler/setup'` (i.e. as early as possible: the sooner
+this is loaded, the sooner it can start optimizing things)
 
 ```ruby
 require 'bootsnap'

--- a/bootsnap.gemspec
+++ b/bootsnap.gemspec
@@ -18,12 +18,16 @@ Gem::Specification.new do |spec|
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.extensions    = ['ext/bootsnap/extconf.rb']
 
-  spec.required_ruby_version = '>= 2.3.0'
+  spec.required_ruby_version = '>= 2.0.0'
+
+  if RUBY_PLATFORM =~ /java/
+    spec.platform = 'java'
+  else
+    spec.platform    = Gem::Platform::RUBY
+    spec.extensions  = ['ext/bootsnap/extconf.rb']
+  end
 
   spec.add_development_dependency "bundler", '~> 1'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/bootsnap/compile_cache.rb
+++ b/lib/bootsnap/compile_cache.rb
@@ -1,14 +1,13 @@
-require_relative 'compile_cache/iseq'
-require_relative 'compile_cache/yaml'
-
 module Bootsnap
   module CompileCache
     def self.setup(cache_dir:, iseq:, yaml:)
       if iseq
+        require_relative 'compile_cache/iseq'
         Bootsnap::CompileCache::ISeq.install!(cache_dir)
       end
 
       if yaml
+        require_relative 'compile_cache/yaml'
         Bootsnap::CompileCache::YAML.install!(cache_dir)
       end
     end

--- a/lib/bootsnap/compile_cache/yaml.rb
+++ b/lib/bootsnap/compile_cache/yaml.rb
@@ -1,3 +1,5 @@
+require 'bootsnap/bootsnap'
+
 module Bootsnap
   module CompileCache
     module YAML

--- a/lib/bootsnap/setup.rb
+++ b/lib/bootsnap/setup.rb
@@ -1,0 +1,47 @@
+require_relative '../bootsnap'
+
+env = ENV['RAILS_ENV'] || ENV['RACK_ENV'] || ENV['ENV']
+development_mode = ['', nil, 'development'].include?(env)
+
+# only enable on 'ruby' (MRI), POSIX (darin, linux, *bsd), and >= 2.3.0
+enable_cc = \
+  RUBY_ENGINE == 'ruby' && \
+  RUBY_PLATFORM =~ /darwin|linux|bsd/ && \
+  RUBY_VERSION                    # "1.9.3"
+    .split('.')                   # ["1", "9", "3"]
+    .map(&:to_i)                  # [1, 9, 3]
+    .zip([2, 3, -1])              # [[1, 2], [9, 3], [3, -1]]
+    .map { |a, b| a <=> b }       # [-1, 1, 1]
+    .detect { |e| !e.zero? }      # -1
+    .==(1)                        # false
+
+cache_dir = ENV['BOOTSNAP_CACHE_DIR']
+unless cache_dir
+  config_dir_frame = caller.detect do |line|
+    line.include?('/config/')
+  end
+
+  unless config_dir_frame
+    $stderr.puts "[bootsnap/setup] couldn't infer cache directory! Either:"
+    $stderr.puts "[bootsnap/setup]   1. require bootsnap/setup from your application's config directory; or"
+    $stderr.puts "[bootsnap/setup]   2. Define the environment variable BOOTSNAP_CACHE_DIR"
+
+    raise "couldn't infer bootsnap cache directory"
+  end
+
+  path = config_dir_frame.split(/:\d+:/).first
+  path = File.dirname(path) until File.basename(path) == 'config'
+  app_root = File.dirname(path)
+
+  cache_dir = File.join(app_root, 'tmp', 'cache')
+end
+
+Bootsnap.setup(
+  cache_dir:            cache_dir,
+  development_mode:     development_mode,
+  load_path_cache:      true,
+  autoload_paths_cache: true, # assume rails. open to PRs to impl. detection
+  disable_trace:        false,
+  compile_cache_iseq:   enable_cc,
+  compile_cache_yaml:   enable_cc
+)


### PR DESCRIPTION
Idea here is to provide a less verbose setup API for rails projects:

```ruby
require 'bundler/setup'
require 'bootsnap/setup'
```

This also makes it "work" on ruby <2.3.0 and jruby (>=2.0.0 compat), and simply doesn't enable the compile-caching feature if the necessary features/platform aren't available.