### PR TITLE
Detect coverage earlier

### DIFF
--- a/ext/bootsnap/bootsnap.c
+++ b/ext/bootsnap/bootsnap.c
@@ -111,6 +111,15 @@ struct s2o_data;
 struct i2o_data;
 struct i2s_data;
 
+/* https://bugs.ruby-lang.org/issues/13667 */
+extern VALUE rb_get_coverages(void);
+static VALUE
+bs_rb_coverage_running(VALUE self)
+{
+  VALUE cov = rb_get_coverages();
+  return RTEST(cov) ? Qtrue : Qfalse;
+}
+
 /*
  * Ruby C extensions are initialized by calling Init_<extname>.
  *
@@ -131,6 +140,7 @@ Init_bootsnap(void)
 
   uncompilable = rb_intern("__bootsnap_uncompilable__");
 
+  rb_define_module_function(rb_mBootsnap_CompileCache_Native, "coverage_running?", bs_rb_coverage_running, 0);
   rb_define_module_function(rb_mBootsnap_CompileCache_Native, "fetch", bs_rb_fetch, 3);
   rb_define_module_function(rb_mBootsnap_CompileCache_Native, "compile_option_crc32=", bs_compile_option_crc32_set, 1);
 }

--- a/lib/bootsnap/compile_cache/iseq.rb
+++ b/lib/bootsnap/compile_cache/iseq.rb
@@ -32,10 +32,7 @@ module Bootsnap
       module InstructionSequenceMixin
         def load_iseq(path)
           # Having coverage enabled prevents iseq dumping/loading.
-          # Ruby unfortunately doesn't give us a good API to actually test
-          # whether coverage is currently enabled, so we have to use this
-          # fairly gross heuristic.
-          return nil if defined?(Coverage)
+          return nil if defined?(Coverage) && Bootsnap::CompileCache::Native.coverage_running?
 
           Bootsnap::CompileCache::Native.fetch(
             Bootsnap::CompileCache::ISeq.cache_dir,

--- a/test/compile_cache_test.rb
+++ b/test/compile_cache_test.rb
@@ -3,6 +3,17 @@ require 'test_helper'
 class CompileCacheTest < Minitest::Test
   include TmpdirHelper
 
+  def test_coverage_running?
+    refute Bootsnap::CompileCache::Native.coverage_running?
+    require 'coverage'
+    begin
+      Coverage.start
+      assert Bootsnap::CompileCache::Native.coverage_running?
+    ensure
+      Coverage.result
+    end
+  end
+
   def test_no_write_permission_to_cache
     path = Help.set_file('a.rb', 'a = 3', 100)
     folder = File.dirname(Help.cache_path(@tmp_dir, path))


### PR DESCRIPTION
@grosser @jules2689 

This should bail out of the iseq caching early enough. Testing whether the constant is defined is *very* fast. This should add less than 2ms to shopify boot.

Where this falls down is if coverage is eager-loaded by something, but not actually used.

The only ruby-land API available to us to test whether coverage is actually running is `Coverage.peek_result`, which appears to be quite expensive if coverage is currently running. I think that's unviable. I wonder if we can add a little function to the C extension to check this more economically.