### PR TITLE
Fix warning when running on Ruby 2.2

### DIFF
--- a/lib/bootsnap/load_path_cache/cache.rb
+++ b/lib/bootsnap/load_path_cache/cache.rb
@@ -9,7 +9,7 @@ module Bootsnap
       def initialize(store, path_obj, development_mode: false)
         @development_mode = development_mode
         @store = store
-        @mutex = ::Thread::Mutex.new
+        @mutex = defined?(::Mutex) ? ::Mutex.new : ::Thread::Mutex.new # TODO: Remove once Ruby 2.2 support is dropped.
         @path_obj = path_obj
         reinitialize
       end


### PR DESCRIPTION
Running Bootsnap on Ruby 2.2 produces this warning:

```
/Users/kasperhansen/.rbenv/versions/2.2.7/gemsets/mainframe/gems/bootsnap-1.1.0/lib/bootsnap/load_path_cache/cache.rb:12: warning: toplevel constant Mutex referenced by Thread::Mutex
/Users/kasperhansen/.rbenv/versions/2.2.7/gemsets/mainframe/gems/bootsnap-1.1.0/lib/bootsnap/load_path_cache/cache.rb:12: warning: toplevel constant Mutex referenced by Thread::Mutex
```

If we do a defined? here that goes away.

Since Bootsnap is going to bundled in Rails 5.x and the minimum Ruby version Rails 5.x supports is 2.2 I think we should run without warnings (…or scissors, but that's another story).