### PR TITLE
Updated README to add require option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This gem works on MacOS and Linux.
 Add `bootsnap` to your `Gemfile`:
 
 ```ruby
-gem 'bootsnap'
+gem 'bootsnap', require: false
 ```
 
 If you are using rails, add this to `config/boot.rb` immediately after `require 'bundler/setup'`:


### PR DESCRIPTION
I've added option `require: false` on Usage. Because this gem doesn't need autorequiring.