### PR TITLE
Fix warnings

### DIFF
--- a/bin/testunit
+++ b/bin/testunit
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 if [ $# -eq 0 ]; then
-  ruby -I"test" -e 'Dir.glob("./test/**/*_test.rb").each { |f| require f }' -- "$@"
+  ruby -I"test" -w -e 'Dir.glob("./test/**/*_test.rb").each { |f| require f }' -- "$@"
 else
   path=$1
-  ruby -I"test" -e "require '${path#test/}'" -- "$@"
+  ruby -I"test" -w -e "require '${path#test/}'" -- "$@"
 fi

--- a/lib/bootsnap/load_path_cache/cache.rb
+++ b/lib/bootsnap/load_path_cache/cache.rb
@@ -35,8 +35,8 @@ module Bootsnap
         acc[base] = nil # enumerator
 
         if [DOT_SO, *DL_EXTENSIONS].include?(ext)
-          DL_EXTENSIONS.each do |ext|
-            acc["#{base}#{ext}"] = nil # enumerator.bundle
+          DL_EXTENSIONS.each do |dl_ext|
+            acc["#{base}#{dl_ext}"] = nil # enumerator.bundle
           end
         end
 

--- a/lib/bootsnap/load_path_cache/cache.rb
+++ b/lib/bootsnap/load_path_cache/cache.rb
@@ -1,4 +1,3 @@
-require_relative '../load_path_cache'
 require_relative '../explicit_require'
 
 module Bootsnap

--- a/lib/bootsnap/load_path_cache/cache.rb
+++ b/lib/bootsnap/load_path_cache/cache.rb
@@ -10,6 +10,7 @@ module Bootsnap
         @store = store
         @mutex = defined?(::Mutex) ? ::Mutex.new : ::Thread::Mutex.new # TODO: Remove once Ruby 2.2 support is dropped.
         @path_obj = path_obj
+        @has_relative_paths = nil
         reinitialize
       end
 

--- a/lib/bootsnap/load_path_cache/path_scanner.rb
+++ b/lib/bootsnap/load_path_cache/path_scanner.rb
@@ -1,5 +1,3 @@
-require_relative '../load_path_cache'
-
 module Bootsnap
   module LoadPathCache
     module PathScanner

--- a/lib/bootsnap/load_path_cache/store.rb
+++ b/lib/bootsnap/load_path_cache/store.rb
@@ -11,6 +11,8 @@ module Bootsnap
 
       def initialize(store_path)
         @store_path = store_path
+        @in_txn = false
+        @dirty = false
         load_data
       end
 

--- a/test/compile_cache_handler_errors_test.rb
+++ b/test/compile_cache_handler_errors_test.rb
@@ -33,7 +33,7 @@ class CompileCacheHandlerErrorsTest < Minitest::Test
   end
 
   def test_storage_to_output_unexpected_type
-    path = Help.set_file('a.rb', 'a = 3', 100)
+    path = Help.set_file('a.rb', 'a = a = 3', 100)
     Bootsnap::CompileCache::ISeq.expects(:storage_to_output).returns(Object.new)
     # It seems like ruby doesn't really care.
     load(path)
@@ -44,7 +44,7 @@ class CompileCacheHandlerErrorsTest < Minitest::Test
   # def test_storage_to_output_invalid_instance_of_expected_type
 
   def test_storage_to_output_raises
-    path = Help.set_file('a.rb', 'a = 3', 100)
+    path = Help.set_file('a.rb', 'a = a = 3', 100)
     klass = Class.new(StandardError)
     Bootsnap::CompileCache::ISeq.expects(:storage_to_output).times(2).raises(klass, 'oops')
     assert_raises(klass) { load(path) }
@@ -53,7 +53,7 @@ class CompileCacheHandlerErrorsTest < Minitest::Test
   end
 
   def test_input_to_output_unexpected_type
-    path = Help.set_file('a.rb', 'a = 3', 100)
+    path = Help.set_file('a.rb', 'a = a = 3', 100)
     Bootsnap::CompileCache::ISeq.expects(:input_to_storage).raises(Bootsnap::CompileCache::Uncompilable)
     Bootsnap::CompileCache::ISeq.expects(:input_to_output).returns(Object.new)
     # It seems like ruby doesn't really care.

--- a/test/compile_cache_test.rb
+++ b/test/compile_cache_test.rb
@@ -31,7 +31,7 @@ class CompileCacheTest < Minitest::Test
   end
 
   def test_can_open_read_only_cache
-    path = Help.set_file('a.rb', 'a = 3', 100)
+    path = Help.set_file('a.rb', 'a = a = 3', 100)
     # Load once to create the cache file
     load(path)
     FileUtils.chmod(0400, path)
@@ -40,7 +40,7 @@ class CompileCacheTest < Minitest::Test
   end
 
   def test_file_is_only_read_once
-    path = Help.set_file('a.rb', 'a = 3', 100)
+    path = Help.set_file('a.rb', 'a = a = 3', 100)
     storage = RubyVM::InstructionSequence.compile_file(path).to_binary
     output = RubyVM::InstructionSequence.load_from_binary(storage)
     # This doesn't really *prove* the file is only read once, but
@@ -60,19 +60,19 @@ class CompileCacheTest < Minitest::Test
   end
 
   def test_no_recache_when_mtime_and_size_same
-    path = Help.set_file('a.rb', 'a = 3', 100)
+    path = Help.set_file('a.rb', 'a = a = 3', 100)
     storage = RubyVM::InstructionSequence.compile_file(path).to_binary
     output = RubyVM::InstructionSequence.load_from_binary(storage)
     Bootsnap::CompileCache::ISeq.expects(:input_to_storage).times(1).returns(storage)
     Bootsnap::CompileCache::ISeq.expects(:storage_to_output).times(2).returns(output)
 
     load(path)
-    Help.set_file(path, 'a = 4', 100)
+    Help.set_file(path, 'a = a = 4', 100)
     load(path)
   end
 
   def test_recache_when_mtime_different
-    path = Help.set_file('a.rb', 'a = 3', 100)
+    path = Help.set_file('a.rb', 'a = a = 3', 100)
     storage = RubyVM::InstructionSequence.compile_file(path).to_binary
     output = RubyVM::InstructionSequence.load_from_binary(storage)
     # Totally lies the second time but that's not the point.
@@ -80,12 +80,12 @@ class CompileCacheTest < Minitest::Test
     Bootsnap::CompileCache::ISeq.expects(:storage_to_output).times(2).returns(output)
 
     load(path)
-    Help.set_file(path, 'a = 2', 101)
+    Help.set_file(path, 'a = a = 2', 101)
     load(path)
   end
 
   def test_recache_when_size_different
-    path = Help.set_file('a.rb', 'a = 3', 100)
+    path = Help.set_file('a.rb', 'a = a = 3', 100)
     storage = RubyVM::InstructionSequence.compile_file(path).to_binary
     output = RubyVM::InstructionSequence.load_from_binary(storage)
     # Totally lies the second time but that's not the point.
@@ -98,7 +98,7 @@ class CompileCacheTest < Minitest::Test
   end
 
   def test_invalid_cache_file
-    path = Help.set_file('a.rb', 'a = 3', 100)
+    path = Help.set_file('a.rb', 'a = a = 3', 100)
     cp = Help.cache_path(@tmp_dir, path)
     FileUtils.mkdir_p(File.dirname(cp))
     File.write(cp, 'nope')


### PR DESCRIPTION
Hi,

This PR fixes some runtime / load time warnings and enables warnings on test.  I need this because enabling debug mode (running Ruby with `-d`) enables warnings, and bootsnap is very noisy with warnings enabled.

Thanks!