### PR TITLE
Follow symlinks while traversing LOAD_PATH

### DIFF
--- a/test/load_path_cache/path_scanner_test.rb
+++ b/test/load_path_cache/path_scanner_test.rb
@@ -1,3 +1,5 @@
+require 'test_helper'
+
 module Bootsnap
   module LoadPathCache
     class PathScannerTest < MiniTest::Test
@@ -6,17 +8,20 @@ module Bootsnap
 
       def test_scans_requirables_and_dirs
         Dir.mktmpdir do |dir|
-          FileUtils.mkdir("#{dir}/a")
-          FileUtils.mkdir("#{dir}/b")
-          FileUtils.mkdir("#{dir}/b/c")
-          FileUtils.touch("#{dir}/d.rb")
-          FileUtils.touch("#{dir}/e.#{DLEXT}")
-          FileUtils.touch("#{dir}/f.#{OTHER_DLEXT}")
-          FileUtils.touch("#{dir}/a/g.rb")
+          FileUtils.mkdir_p("#{dir}/ruby/a")
+          FileUtils.mkdir_p("#{dir}/ruby/b/c")
+          FileUtils.mkdir_p("#{dir}/support/h/i")
+          FileUtils.touch("#{dir}/ruby/d.rb")
+          FileUtils.touch("#{dir}/ruby/e.#{DLEXT}")
+          FileUtils.touch("#{dir}/ruby/f.#{OTHER_DLEXT}")
+          FileUtils.touch("#{dir}/ruby/a/g.rb")
+          FileUtils.touch("#{dir}/support/h/j.rb")
+          FileUtils.touch("#{dir}/support/h/i/k.rb")
+          FileUtils.ln_s("#{dir}/support/h", "#{dir}/ruby/h")
 
-          entries, dirs = PathScanner.call(dir)
-          assert_equal(["a/g.rb", "d.rb", "e.#{DLEXT}"], entries.sort)
-          assert_equal(["a", "b", "b/c"], dirs.sort)
+          entries, dirs = PathScanner.call("#{dir}/ruby")
+          assert_equal(["a/g.rb", "d.rb", "e.#{DLEXT}", "h/i/k.rb", "h/j.rb"], entries.sort)
+          assert_equal(["a", "b", "b/c", "h", "h/i"], dirs.sort)
         end
       end
     end


### PR DESCRIPTION
When I was trying to setup bootsnap in our project I had troubles with loading `psych/exception` and `bigdecimal/util` files. It turned out we have `psych` and `bigdecimal` directories *symlinked* in `/usr/share/ruby` dir and bootsnap does not follow symlinks. It is how ruby gems are provided on CentOS.