### PR TITLE
Allow preprocessing content before it is cached

### DIFF
--- a/lib/bootsnap.rb
+++ b/lib/bootsnap.rb
@@ -12,7 +12,8 @@ module Bootsnap
     autoload_paths_cache: true,
     disable_trace: false,
     compile_cache_iseq: true,
-    compile_cache_yaml: true
+    compile_cache_yaml: true,
+    preprocesser: nil
   )
     if autoload_paths_cache && !load_path_cache
       raise InvalidConfiguration, "feature 'autoload_paths_cache' depends on feature 'load_path_cache'"
@@ -29,7 +30,8 @@ module Bootsnap
     Bootsnap::CompileCache.setup(
       cache_dir: cache_dir + '/bootsnap-compile-cache',
       iseq: compile_cache_iseq,
-      yaml: compile_cache_yaml
+      yaml: compile_cache_yaml,
+      preprocessor: preprocessor
     )
   end
 

--- a/lib/bootsnap/compile_cache.rb
+++ b/lib/bootsnap/compile_cache.rb
@@ -1,14 +1,25 @@
 module Bootsnap
   module CompileCache
-    def self.setup(cache_dir:, iseq:, yaml:)
+    class DefaultPreprocessor
+      def call(contents, path)
+        contents
+      end
+    end
+
+    def self.setup(cache_dir:, iseq:, yaml:, preprocessor: nil)
+      if preprocessor && !preprocessor.respond_to?(:call)
+        raise ArgumentError, 'Invalid preprocessor, must respond to #call'
+      end
+      preprocessor ||= DefaultPreprocessor.new
+
       if iseq
         require_relative 'compile_cache/iseq'
-        Bootsnap::CompileCache::ISeq.install!(cache_dir)
+        Bootsnap::CompileCache::ISeq.install!(cache_dir, preprocessor)
       end
 
       if yaml
         require_relative 'compile_cache/yaml'
-        Bootsnap::CompileCache::YAML.install!(cache_dir)
+        Bootsnap::CompileCache::YAML.install!(cache_dir, preprecessor)
       end
     end
   end

--- a/lib/bootsnap/compile_cache/iseq.rb
+++ b/lib/bootsnap/compile_cache/iseq.rb
@@ -5,11 +5,11 @@ module Bootsnap
   module CompileCache
     module ISeq
       class << self
-        attr_accessor :cache_dir
+        attr_accessor :cache_dir, :preprocessor
       end
 
-      def self.input_to_storage(_, path)
-        RubyVM::InstructionSequence.compile_file(path).to_binary
+      def self.input_to_storage(contents, path)
+        RubyVM::InstructionSequence.compile(preprocessor.call(contents, path)).to_binary
       rescue SyntaxError
         raise Uncompilable, 'syntax error'
       end
@@ -58,8 +58,9 @@ module Bootsnap
         Bootsnap::CompileCache::Native.compile_option_crc32 = crc
       end
 
-      def self.install!(cache_dir)
+      def self.install!(cache_dir, preprocessor)
         Bootsnap::CompileCache::ISeq.cache_dir = cache_dir
+        Bootsnap::CompileCache::ISeq.preprocessor = preprocessor
         Bootsnap::CompileCache::ISeq.compile_option_updated
         class << RubyVM::InstructionSequence
           prepend InstructionSequenceMixin

--- a/test/preprocessor_test.rb
+++ b/test/preprocessor_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+class PreprocessorTest < Minitest::Test
+  class NumberSigilPreprocessor
+    def call(contents, _)
+      contents.gsub(%r{~n\(([\d\s+-/*\(\)]+?)\)}) do |match|
+        eval(match[3..-2])
+      end
+    end
+  end
+
+  class << self
+    attr_accessor :response
+  end
+
+  def test_iseq
+    with_preprocessor do
+      contents = "PreprocessorTest.response = ~n(1 + 2)"
+      storage = Bootsnap::CompileCache::ISeq.input_to_storage(contents, nil)
+      output = Bootsnap::CompileCache::ISeq.storage_to_output(storage)
+
+      self.class.response = nil
+      output.eval
+      assert_equal 3, self.class.response
+    end
+  end
+
+  private
+
+  def with_preprocessor
+    previous = Bootsnap::CompileCache::ISeq.preprocessor
+    Bootsnap::CompileCache::ISeq.preprocessor = NumberSigilPreprocessor.new
+    yield
+    Bootsnap::CompileCache::ISeq.preprocessor = previous
+  end
+end


### PR DESCRIPTION
Since bootsnap is already hooking into the compile chain, this additionally allows the files to be preprocessed before they are compiled. This opens up a bunch of different possibilities, like macros or AST rewriting. Mostly this allows me to hook it into my own preprocessing gem (http://github.com/kddeisz/vernacular). Let me know what you think and what else might need to happen to get this merged.