### PR TITLE
Avoid loading a constant twice by checking if it is already defined

### DIFF
--- a/lib/bootsnap/load_path_cache/core_ext/active_support.rb
+++ b/lib/bootsnap/load_path_cache/core_ext/active_support.rb
@@ -2,15 +2,6 @@ module Bootsnap
   module LoadPathCache
     module CoreExt
       module ActiveSupport
-        def self.with_bootsnap_fallback(error)
-          yield
-        rescue error => e
-          # NoMethodError is a NameError, but we only want to handle actual
-          # NameError instances.
-          raise unless e.class == error
-          without_bootsnap_cache { yield }
-        end
-
         def self.without_bootsnap_cache
           prev = Thread.current[:without_bootsnap_cache] || false
           Thread.current[:without_bootsnap_cache] = true
@@ -50,13 +41,21 @@ module Bootsnap
           # behaviour.  The gymnastics here are a bit awkward, but it prevents
           # 200+ lines of monkeypatches.
           def load_missing_constant(from_mod, const_name)
-            CoreExt::ActiveSupport.with_bootsnap_fallback(NameError) { super }
+            super
+          rescue NameError => e
+            # NoMethodError is a NameError, but we only want to handle actual
+            # NameError instances.
+            raise unless e.class == NameError
+            raise if from_mod.const_defined?(const_name)
+            without_bootsnap_cache { super }
           end
 
           # Signature has changed a few times over the years; easiest to not
           # reiterate it with version polymorphism here...
           def depend_on(*)
-            CoreExt::ActiveSupport.with_bootsnap_fallback(LoadError) { super }
+            super
+          rescue LoadError
+            without_bootsnap_cache { super }
           end
         end
       end


### PR DESCRIPTION
Fixes #74
cc @patrickdonovan since this just caused you some confusion today and would have given you the relevant error

`load_missing_constant` has a fallback for when the constant can't be loaded from the cache, so that it will try without using the cache.  However, it does this when it receives a `NameError` exception, which could happen from an unrelated bug that happen in the file that loads that constant.

The fix was to use another condition that checks if the constant is already defined, rather than assuming the NameError was from the `return from_mod.const_get(const_name)` line in ActiveSupport::Dependencies.load_missing_constant.

I've tested with @patrickdonovan's branch in Shopify and using the code in https://github.com/xuorig/bootsnap-issue to make sure this is fixed.  The test suite doesn't really cover the active support extensions right now.