### PR TITLE
Works without bundler

### DIFF
--- a/lib/bootsnap.rb
+++ b/lib/bootsnap.rb
@@ -1,4 +1,5 @@
 require_relative 'bootsnap/version'
+require_relative 'bootsnap/bundler'
 require_relative 'bootsnap/load_path_cache'
 require_relative 'bootsnap/compile_cache'
 

--- a/lib/bootsnap/bundler.rb
+++ b/lib/bootsnap/bundler.rb
@@ -1,0 +1,12 @@
+module Bootsnap
+  module_function
+
+  def bundler?
+    # Bundler environment variable
+    ['BUNDLE_BIN_PATH', 'BUNDLE_GEMFILE'].each do |current|
+      return true if ENV.key?(current)
+    end
+    
+    false
+  end
+end

--- a/lib/bootsnap/load_path_cache/path.rb
+++ b/lib/bootsnap/load_path_cache/path.rb
@@ -99,7 +99,7 @@ module Bootsnap
         @stability ||= begin
           if Gem.path.detect { |p| expanded_path.start_with?(p.to_s) }
             STABLE
-          elsif expanded_path.start_with?(Bundler.bundle_path.to_s)
+          elsif Bootsnap.bundler? && expanded_path.start_with?(Bundler.bundle_path.to_s)
             STABLE
           elsif expanded_path.start_with?(RUBY_LIBDIR) && !expanded_path.start_with?(RUBY_SITEDIR)
             STABLE

--- a/lib/bootsnap/load_path_cache/path_scanner.rb
+++ b/lib/bootsnap/load_path_cache/path_scanner.rb
@@ -15,7 +15,8 @@ module Bootsnap
       REQUIRABLES_AND_DIRS = "/{,*/**/}*{#{DOT_RB},#{DL_EXTENSIONS.join(',')},/}"
       NORMALIZE_NATIVE_EXTENSIONS = !DL_EXTENSIONS.include?(LoadPathCache::DOT_SO)
       ALTERNATIVE_NATIVE_EXTENSIONS_PATTERN = /\.(o|bundle|dylib)\z/
-      BUNDLE_PATH = (Bundler.bundle_path.cleanpath.to_s << LoadPathCache::SLASH).freeze
+      BUNDLE_PATH = Bootsnap.bundler? ?
+        (Bundler.bundle_path.cleanpath.to_s << LoadPathCache::SLASH).freeze : ''.freeze
 
       def self.call(path)
         path = path.to_s


### PR DESCRIPTION
Currently, `bootsnap` has strongly dependency to `bundler` gem.

I want to use `bootsnap` in command-line tools.
https://github.com/fastlane/fastlane/pull/10536

However, the command-line tools might work without bundler.

So, I will weaken the dependence in this pull request.