### PR TITLE
Path tests: Add assertion failure messages

### DIFF
--- a/test/load_path_cache/path_test.rb
+++ b/test/load_path_cache/path_test.rb
@@ -19,16 +19,16 @@ module Bootsnap
 
         Bundler.stubs(:bundle_path).returns('/bp')
 
-        assert stable.stable?
-        refute stable.volatile?
-        assert volatile.volatile?
-        refute volatile.stable?
-        assert unknown.volatile?
-        refute unknown.stable?
+        assert stable.stable?, "The stable path #{stable.path.inspect} was unexpectedly not stable."
+        refute stable.volatile?, "The stable path #{stable.path.inspect} was unexpectedly volatile."
+        assert volatile.volatile?, "The volatile path #{volatile.path.inspect} was unexpectedly not volatile."
+        refute volatile.stable?, "The volatile path #{volatile.path.inspect} was unexpectedly stable."
+        assert unknown.volatile?, "The unknown path #{unknown.path.inspect} was unexpectedly not volatile."
+        refute unknown.stable?, "The unknown path #{unknown.path.inspect} was unexpectedly stable."
 
-        assert lib.stable?
-        refute site.stable?
-        assert bundler.stable?
+        assert lib.stable?, "The lib path #{lib.path.inspect} was unexpectedly not stable."
+        refute site.stable?, "The site path #{site.path.inspect} was unexpectedly stable."
+        assert bundler.stable?, "The bundler path #{bundler.path.inspect} was unexpectedly not stable."
       end
 
       def test_non_directory?


### PR DESCRIPTION
As a part of uncovering what is ailing the `stable` Path, **this PR adds a few descriptions** to asserts.

Example running tests with these asserts:

```
Run options: --seed 57321

# Running:

.F...........................................

Finished in 0.062685s, 717.8705 runs/s, 1579.3151 assertions/s.

  1) Failure:
Bootsnap::LoadPathCache::PathTest#test_stability [/Users/olle/opensource/bootsnap/test/load_path_cache/path_test.rb:22]:
The stable path "/Users/olle/.rvm/rubies/ruby-2.4.0/lib/ruby/site_ruby/2.4.0/bundler.rb" was unexpectedly not stable.

45 runs, 99 assertions, 1 failures, 0 errors, 0 skips
```

For reference, here is the the code which sets up the `stable` variable referred to in the failure message:

```ruby
bundler_file = Bundler.method(:setup).source_location[0]
# ...
stable       = Path.new(bundler_file)
```
