### PR TITLE
Travis: Switch to Linux, use preinstalled ruby-2.4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-os: osx
 language: ruby
-rvm: ruby-2.4.0
+rvm: ruby-2.4.1
 before_script: rake
 script: bin/testunit


### PR DESCRIPTION
This PR is about trying to get **faster test feedback**, by running on default nodes, which have a few versions of Ruby pre-installed. 

This build was 32s, other PRs were about 1 min.

Benefits:

- less time spent in Travis build queue
- less time spent in the `rvm` step

Drawbacks

- a test failure (see below)
