### PR TITLE
tag exceptions with the library call they were actually generated by

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -5,5 +5,6 @@ up:
   - ruby: 2.3.3
   - bundler
 commands:
+  build: rake compile
   test: 'rake compile && exec bin/testunit'
   style: 'exec rubocop -D'


### PR DESCRIPTION
`Errno::*` exceptions will now look like:

```
(bs)/compile_cache/iseq.rb:37:in `fetch': Bad file descriptor - bs_fetch:open_cache_file:read (Errno::EBADF)
        from (bs)/compile_cache/iseq.rb:37:in `load_iseq'
```

This should at least make it a little easier to debug errors like https://github.com/Shopify/bootsnap/issues/104