### PR TITLE
Handle cache file collisions

### DIFF
--- a/lib/bootsnap/load_path_cache/store.rb
+++ b/lib/bootsnap/load_path_cache/store.rb
@@ -71,8 +71,11 @@ module Bootsnap
         # caches if they read at an inopportune time.
         tmp = "#{@store_path}.#{Process.pid}.#{(rand * 100000).to_i}.tmp"
         FileUtils.mkpath(File.dirname(tmp))
-        File.binwrite(tmp, MessagePack.dump(@data))
+        exclusive_write = File::Constants::CREAT | File::Constants::EXCL | File::Constants::WRONLY
+        File.binwrite(tmp, MessagePack.dump(@data), mode: exclusive_write)
         FileUtils.mv(tmp, @store_path)
+      rescue Errno::EEXIST
+        retry
       end
     end
   end

--- a/test/load_path_cache/store_test.rb
+++ b/test/load_path_cache/store_test.rb
@@ -63,6 +63,16 @@ module Bootsnap
         store.transaction { store.set('a', 1) }
         assert File.exist?(@path)
       end
+
+      def test_retry_on_collision
+        retries = sequence('retries')
+
+        File.expects(:binwrite).in_sequence(retries).raises(Errno::EEXIST.new("File exists @ rb_sysopen"))
+        File.expects(:binwrite).in_sequence(retries).returns(1)
+        FileUtils.expects(:mv).in_sequence(retries)
+
+        store.transaction { store.set('a', 1) }
+      end
     end
   end
 end


### PR DESCRIPTION
Related to issue #107, commit c672921 improved the situation by adding a pid to the temporary name. This change improves the guarantee by allowing a file to be created only if one doesn't exist yet, or retrying with a new name otherwise.