### PR TITLE
Fix lookup of errno constant, Ruby 2.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: ruby
-rvm: ruby-2.4.1
+
+rvm:
+  - ruby-2.4
+  - ruby-2.5
+
 before_script: rake
-script: bin/testunit
+script: bundle exec bin/testunit

--- a/test/compile_cache_key_format_test.rb
+++ b/test/compile_cache_key_format_test.rb
@@ -62,6 +62,12 @@ class CompileCacheKeyFormatTest < Minitest::Test
     assert_equal('NEATO /DEV/NULL', actual)
   end
 
+  def test_unexistent_fetch
+    assert_raises(Errno::ENOENT) do
+      Bootsnap::CompileCache::Native.fetch(@tmp_dir, '123', Bootsnap::CompileCache::ISeq)
+    end
+  end
+
   private
 
   def cache_key_for_file(file)


### PR DESCRIPTION
Unfortunately, Ruby 2.5 changed the order of `Errno.constants` and we can't rely on the index inside array.

```
2.4.2 :014 > Errno.constants.map { |c| Errno.const_get(c)::Errno }
 => [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 35, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 11, 63, 77, 78, 66, 62, 35, 91, 90, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 99, 96, 101, 98, 0, 0, 71, 97, 0, 0, 0, 100, 95, 0, 94, 84, 0, 0, 0, 0, 0, 0, 0, 0, 92, 0, 0, 68, 38, 39, 40, 41, 42, 43, 44, 102, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 64, 65, 37, 36, 70, 0, 0, 0, 0, 0, 69, 89, 0, 0, 0, 0, 0, 0, 104, 105, 0, 80, 72, 0, 79, 81, 93, 45, 67, 76, 75, 74, 73, 0, 0, 0, 0]
```

```
2.5.0 :012 > Errno.constants.map { |c| Errno.const_get(c)::Errno }
 => [104, 105, 0, 80, 72, 0, 79, 81, 93, 45, 67, 76, 75, 74, 73, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 35, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 11, 63, 77, 78, 66, 62, 35, 91, 90, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 99, 96, 101, 98, 0, 0, 71, 97, 0, 0, 0, 100, 95, 0, 94, 84, 0, 0, 0, 0, 0, 0, 0, 0, 92, 0, 0, 68, 38, 39, 40, 41, 42, 43, 44, 102, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 64, 65, 37, 36, 70, 0, 0, 0, 0, 0, 69, 89, 0, 0, 0, 0, 0, 0]
```


The underlying problem with that is overloaded `YAML.load_file` which cause inappropriate exception on file errors

```
# Bootsnap enabled
[1] pry(main)> YAML.load_file('123')
Errno::NOERROR: Undefined error: 0 - bs_fetch:open_current_file:open
from /Users/toad/.rvm/gems/ruby-2.5.0@onvard/gems/bootsnap-1.1.8/lib/bootsnap/compile_cache/yaml.rb:49:in `fetch'

# Bootsnap disabled
[1] pry(main)> YAML.load_file('123')
Errno::ENOENT: No such file or directory @ rb_sysopen - 123
from /Users/toad/.rvm/rubies/ruby-2.5.0/lib/ruby/2.5.0/psych.rb:497:in `initialize'
```


The proposed PR uses the convenient `rb_syserr_new` method https://github.com/ruby/ruby/blob/trunk/error.c#L2462