### PR TITLE
$LOAD_PATH optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ Add `bootsnap` to your `Gemfile`:
 gem 'bootsnap', require: false
 ```
 
-If you are using Rails, add this to `config/boot.rb` immediately after `require 'bundler/setup'`:
+If you are using Rails, add this to `config/boot.rb` (and remove `bundler/setup` if you have it):
 
 ```ruby
+require 'bundler'
+Bundler.setup(:default, ENV.fetch('RAILS_ENV', :development)) # Makes sure your $LOAD_PATH only contains the necessary gems
 require 'bootsnap/setup'
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,11 +18,15 @@ Add `bootsnap` to your `Gemfile`:
 gem 'bootsnap', require: false
 ```
 
-If you are using Rails, add this to `config/boot.rb` (and remove `bundler/setup` if you have it):
-
+If you are using Rails, add this to `config/boot.rb` immediately after require `bundler/setup` or a `Bundler.setup` call:
+```ruby
+ require 'bundler/setup'
+ require 'bootsnap/setup'
+```
+Protip: Using Bundler.setup like in the example below can _further_ improve boot time by reducing the `$LOAD_PATH` to only include gems for the given environment
 ```ruby
 require 'bundler'
-Bundler.setup(:default, ENV.fetch('RAILS_ENV', :development)) # Makes sure your $LOAD_PATH only contains the necessary gems
+Bundler.setup(:default, ENV.fetch('RAILS_ENV', :development))
 require 'bootsnap/setup'
 ```
 


### PR DESCRIPTION
First off, this gem is dope 💯  🏀  🔥  . I think I've found a way to make it even faster 📊  💯 

`require bundler/setup` runs `Bundler.setup` with no group arguments by default. If you have a very deep `$LOAD_PATH`, you can avoid polluting it with with gems that are not relevant to the current environment.

I'm not sure this will apply to every project, but considering this gem is all about boot speed, it feels like mentioning this is a good idea in the README.

Thanks!