### PR TITLE
Explicitly mention what `disable_trace` does and the side effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Bootsnap.setup(
   development_mode:     env == 'development', # Current working environment, e.g. RACK_ENV, RAILS_ENV, etc
   load_path_cache:      true,                 # Optimize the LOAD_PATH with a cache
   autoload_paths_cache: true,                 # Optimize ActiveSupport autoloads with cache
-  disable_trace:        true,                 # (Alpha) Set `RubyVM::InstructionSequence.compile_option = { trace_instruction: false }`
+  disable_trace:        env == 'production',  # Set `RubyVM::InstructionSequence.compile_option = { trace_instruction: false }`. Disables all interactive debuggers and TracePoint features.
   compile_cache_iseq:   true,                 # Compile Ruby code into ISeq cache, breaks coverage reporting.
   compile_cache_yaml:   true                  # Compile YAML into a cache
 )


### PR DESCRIPTION
We used to have something in the README about `disable_trace` hinting
that it was incompatible with any tools that used `trace` functionality
and that for that reason Shopify didn't really use it that much.

It was super-surprising to me when I added Bootsnap to suddenly have
engineer debug workflows affected by it. A better description of the
side effect of the setting might have helped me narrow it down quicker
or prevented me shipping it in the first place with traces disabled.