### PR TITLE
Use realpaths in Cache @path_obj

### DIFF
--- a/lib/bootsnap/load_path_cache.rb
+++ b/lib/bootsnap/load_path_cache.rb
@@ -21,12 +21,14 @@ module Bootsnap
     CACHED_EXTENSIONS = DLEXT2 ? [DOT_RB, DLEXT, DLEXT2] : [DOT_RB, DLEXT]
 
     class << self
-      attr_reader :load_path_cache, :autoload_paths_cache, :loaded_features_index
+      attr_reader :load_path_cache, :autoload_paths_cache,
+                  :loaded_features_index, :realpath_cache
 
       def setup(cache_path:, development_mode:, active_support: true)
         store = Store.new(cache_path)
 
         @loaded_features_index = LoadedFeaturesIndex.new
+        @realpath_cache = RealpathCache.new
 
         @load_path_cache = Cache.new(store, $LOAD_PATH, development_mode: development_mode)
         require_relative 'load_path_cache/core_ext/kernel_require'
@@ -53,3 +55,4 @@ require_relative 'load_path_cache/cache'
 require_relative 'load_path_cache/store'
 require_relative 'load_path_cache/change_observer'
 require_relative 'load_path_cache/loaded_features_index'
+require_relative 'load_path_cache/realpath_cache'

--- a/lib/bootsnap/load_path_cache/cache.rb
+++ b/lib/bootsnap/load_path_cache/cache.rb
@@ -9,7 +9,7 @@ module Bootsnap
         @development_mode = development_mode
         @store = store
         @mutex = defined?(::Mutex) ? ::Mutex.new : ::Thread::Mutex.new # TODO: Remove once Ruby 2.2 support is dropped.
-        @path_obj = path_obj
+        @path_obj = path_obj.map { |f| File.exist?(f) ? File.realpath(f) : f }
         @has_relative_paths = nil
         reinitialize
       end

--- a/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb
+++ b/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb
@@ -36,6 +36,14 @@ module Kernel
     require_with_bootsnap_lfi(path)
   end
 
+  alias_method :require_relative_without_bootsnap, :require_relative
+  def require_relative(path)
+    realpath = Bootsnap::LoadPathCache.realpath_cache.call(
+      caller_locations(1..1).first.absolute_path, path
+    )
+    require(realpath)
+  end
+
   alias_method :load_without_bootsnap, :load
   def load(path, wrap = false)
     if resolved = Bootsnap::LoadPathCache.load_path_cache.find(path)
@@ -76,6 +84,14 @@ class << Kernel
     return false
   rescue Bootsnap::LoadPathCache::FallbackScan
     require_with_bootsnap_lfi(path)
+  end
+
+  alias_method :require_relative_without_bootsnap, :require_relative
+  def require_relative(path)
+    realpath = Bootsnap::LoadPathCache.realpath_cache.call(
+      caller_locations(1..1).first.absolute_path, path
+    )
+    require(realpath)
   end
 
   alias_method :load_without_bootsnap, :load

--- a/lib/bootsnap/load_path_cache/realpath_cache.rb
+++ b/lib/bootsnap/load_path_cache/realpath_cache.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Bootsnap
+  module LoadPathCache
+    class RealpathCache
+      def initialize
+        @cache = Hash.new { |h, k| h[k] = realpath(*k) }
+      end
+
+      def call(*key)
+        @cache[key]
+      end
+
+      private
+
+      def realpath(caller_location, path)
+        base = File.dirname(caller_location)
+        file = find_file(File.expand_path(path, base))
+        dir = File.dirname(file)
+        File.join(dir, File.basename(file))
+      end
+
+      def find_file(name)
+        ['', *CACHED_EXTENSIONS].each do |ext|
+          filename = "#{name}#{ext}"
+          return File.realpath(filename) if File.exist?(filename)
+        end
+        name
+      end
+    end
+  end
+end

--- a/test/load_path_cache/realpath_cache_test.rb
+++ b/test/load_path_cache/realpath_cache_test.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Bootsnap
+  module LoadPathCache
+    class RealpathCacheTest < MiniTest::Test
+      EXTENSIONS = ['', *CACHED_EXTENSIONS]
+
+      def setup
+        @cache = RealpathCache.new
+        @base_dir = Dir.mktmpdir
+        @absolute_dir = "#{@base_dir}/absolute"
+        Dir.mkdir(@absolute_dir)
+
+        @symlinked_dir = "#{@base_dir}/symlink"
+        FileUtils.ln_s(@absolute_dir, @symlinked_dir)
+
+        real_caller = File.new("#{@absolute_dir}/real_caller.rb", 'w').path
+        symlinked_caller = "#{@absolute_dir}/symlinked_caller.rb"
+
+        FileUtils.ln_s(real_caller, symlinked_caller)
+
+        EXTENSIONS.each do |ext|
+          real_required = File.new("#{@absolute_dir}/real_required#{ext}", 'w').path
+
+          symlinked_required = "#{@absolute_dir}/symlinked_required#{ext}"
+          FileUtils.ln_s(real_required, symlinked_required)
+        end
+      end
+
+      def teardown
+        FileUtils.remove_entry(@base_dir)
+      end
+
+      def remove_required(extensions)
+        extensions.each do |ext|
+          FileUtils.rm("#{@absolute_dir}/real_required#{ext}")
+          FileUtils.rm("#{@absolute_dir}/symlinked_required#{ext}")
+        end
+      end
+
+      variants = %w(absolute symlink).product(%w(absolute symlink),
+        %w(real_caller symlinked_caller),
+        %w(real_required symlinked_required))
+
+      variants.each do |caller_dir, required_dir, caller_file, required_file|
+        method_name = "test_with_#{caller_dir}_caller_dir_" \
+                      "#{required_dir}_require_dir_" \
+                      "#{caller_file}_#{required_file}"
+        define_method(method_name) do
+          caller_path = "#{@base_dir}/#{caller_dir}/#{caller_file}"
+          require_path = "../#{required_dir}/#{required_file}.rb"
+
+          expected = "#{@absolute_dir}/real_required.rb"
+
+          assert @cache.call(caller_path, require_path).eql?(expected)
+        end
+
+        (EXTENSIONS.size - 1).times do |n|
+          removing = EXTENSIONS[0..n]
+
+          define_method("#{method_name}_no#{removing.join('_')}_extensions") do
+            caller_path = "#{@base_dir}/#{caller_dir}/#{caller_file}"
+            require_path = "../#{required_dir}/#{required_file}"
+
+            remove_required(removing)
+
+            expected = "#{@absolute_dir}/real_required#{EXTENSIONS[n + 1]}"
+
+            assert @cache.call(caller_path, require_path).eql?(expected)
+          end
+        end
+
+        define_method("#{method_name}_no_files") do
+          caller_path = "#{@base_dir}/#{caller_dir}/#{caller_file}"
+          require_path = "../#{required_dir}/#{required_file}"
+
+          remove_required(EXTENSIONS)
+
+          expected = "#{@base_dir}/#{required_dir}/#{required_file}"
+          assert @cache.call(caller_path, require_path).eql?(expected)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
If gems are loaded from symlinked directory, $LOAD_PATH has mixed symlinked
and real paths, while subsequent `require`s are resolved to real path, so we can
end up in situation when we rerequire the same gem with different path, `require`
loads this gem again and things go BOOM. for example:
```
From: /…/src/bootsnap/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb @ line 18 Kernel#require:

    15: def require(path)
    16:   if resolved = Bootsnap::LoadPathCache.load_path_cache.find(path)
    17:     binding.pry if path == 'set'
 => 18:     require_without_cache(resolved)
    19:   else
    20:     raise Bootsnap::LoadPathCache::CoreExt.make_load_error(path)
    21:   end
    22: rescue Bootsnap::LoadPathCache::ReturnFalse
    23:   return false
    24: rescue Bootsnap::LoadPathCache::FallbackScan
    25:   require_without_cache(path)
    26: end

[1] pry(main)> path
=> "set"
[2] pry(main)> Set.new.method(:to_s).source_location
=> ["/real_path/.rvm/rubies/ruby-2.5.0/lib/ruby/2.5.0/set.rb", 629]
[3] pry(main)> resolved
=> "/symlinked_path/.rvm/rubies/ruby-2.5.0/lib/ruby/2.5.0/set.rb"
[4] pry(main)> require_without_cache(resolved)
/symlinked_path/.rvm/rubies/ruby-2.5.0/lib/ruby/2.5.0/set.rb:625: warning: already initialized constant Set::InspectKey
/real_path/.rvm/rubies/ruby-2.5.0/lib/ruby/2.5.0/set.rb:625: warning: previous definition of InspectKey was here
=> true
[5] pry(main)> Set.new.method(:to_s).source_location
=> ["/symlinked_path/.rvm/rubies/ruby-2.5.0/lib/ruby/2.5.0/set.rb", 629]
[6] pry(main)>
```