### PR TITLE
Don't make Kernel#require and Kernel#load public

### DIFF
--- a/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb
+++ b/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb
@@ -11,6 +11,8 @@ module Bootsnap
 end
 
 module Kernel
+  private
+
   alias_method :require_without_bootsnap, :require
 
   # Note that require registers to $LOADED_FEATURES while load does not.


### PR DESCRIPTION
The `require` and `load` instance methods on the Kernel module are private. By redefining them without using an access modifier, Bootsnap was making them public.

When Bootsnap is used in a Rails app, `ActiveSupport::Dependencies` will be loaded and [make them private again](https://github.com/rails/rails/blob/4c9c3ffc2e80155f31dbcf80591618ed1c858685/activesupport/lib/active_support/dependencies.rb#L273-L285), so the change in visibility isn't likely to be noticed. However in https://github.com/rails/rails/pull/32065, [this line](https://github.com/rails/rails/blob/92dac547fdf073e034c11a452d3b965a38a0f948/activesupport/lib/active_support/deprecation/proxy_wrappers.rb#L15) was getting run before that could happen, and `require` was incorrectly removed from the class; causing [this error](https://travis-ci.org/rails/rails/jobs/356863489#L2552) and necessitating [this workaround](https://github.com/rails/rails/commit/a252858689c867021969bac7e224eda57a49514a).