### PR TITLE
Use 'mocha/minitest' since 'mocha/mini_test'` has been deprecated

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,7 +6,7 @@ require 'tmpdir'
 require 'fileutils'
 
 require 'minitest/autorun'
-require 'mocha/mini_test'
+require 'mocha/minitest'
 
 cache_dir = File.expand_path('../../tmp/bootsnap-compile-cache', __FILE__)
 Bootsnap::CompileCache.setup(cache_dir: cache_dir, iseq: true, yaml: false)


### PR DESCRIPTION
Refer https://github.com/freerange/mocha/pull/322

This pull request addresses ```Mocha deprecation warning at /home/yahonda/git/bootsnap/test/test_helper.rb:9:in `require': `require 'mocha/mini_test'` has been deprecated. Please use `require 'mocha/minitest' instead.```

```ruby
$ bundle exec bin/testunit
Mocha deprecation warning at /home/yahonda/git/bootsnap/test/test_helper.rb:9:in `require': `require 'mocha/mini_test'` has been deprecated. Please use `require 'mocha/minitest' instead.
Run options: --seed 27668

# Running:

....................................................

Finished in 0.067781s, 767.1757 runs/s, 2035.9662 assertions/s.

52 runs, 138 assertions, 0 failures, 0 errors, 0 skips
$
```