### PR TITLE
Pass block to wrapped method in ChangeObserver

### DIFF
--- a/lib/bootsnap/load_path_cache/change_observer.rb
+++ b/lib/bootsnap/load_path_cache/change_observer.rb
@@ -45,8 +45,8 @@ module Bootsnap
           reject! reverse! select! shuffle! shift slice! sort! sort_by!
         ).each do |meth|
           sc.send(:alias_method, :"#{meth}_without_lpc", meth)
-          arr.define_singleton_method(meth) do |*a|
-            send(:"#{meth}_without_lpc", *a)
+          arr.define_singleton_method(meth) do |*a, &block|
+            send(:"#{meth}_without_lpc", *a, &block)
             observer.reinitialize
           end
         end

--- a/test/load_path_cache/change_observer_test.rb
+++ b/test/load_path_cache/change_observer_test.rb
@@ -25,9 +25,9 @@ module Bootsnap
         @observer.expects(:reinitialize).times(3)
         @arr.delete(3)
         @arr.compact!
-        @arr.map!(&:foo)
+        @arr.map!(&:upcase)
 
-        assert_equal(%w(d e a b c f g), @arr)
+        assert_equal(%w(D E A B C F G), @arr)
       end
     end
   end


### PR DESCRIPTION
## Problem

The tests actually demonstrate this problem well, since it was doing `@arr.map!(&:foo)` on an array of strings and it wasn't resulting in a ```NoMethodError: undefined method `foo' for "d":String``` error since it wasn't actually passing the block to `map!`

## Solution

Pass the block in ChangeObserver so array methods like `map!` actually modify the array.