### PR TITLE
Wrap more methods in ChangeObserver and fix return values

### DIFF
--- a/lib/bootsnap/load_path_cache/change_observer.rb
+++ b/lib/bootsnap/load_path_cache/change_observer.rb
@@ -41,8 +41,9 @@ module Bootsnap
         # accounting cost would be greater than the hit from these, since we
         # actively discourage calling them.
         %i(
-          collect! compact! delete delete_at delete_if fill flatten! insert map!
-          reject! reverse! select! shuffle! shift slice! sort! sort_by!
+          []= clear collect! compact! delete delete_at delete_if fill flatten!
+          insert keep_if map! pop reject! replace reverse! rotate! select!
+          shift shuffle! slice! sort! sort_by! uniq!
         ).each do |meth|
           sc.send(:alias_method, :"#{meth}_without_lpc", meth)
           arr.define_singleton_method(meth) do |*a, &block|

--- a/lib/bootsnap/load_path_cache/change_observer.rb
+++ b/lib/bootsnap/load_path_cache/change_observer.rb
@@ -47,8 +47,9 @@ module Bootsnap
         ).each do |meth|
           sc.send(:alias_method, :"#{meth}_without_lpc", meth)
           arr.define_singleton_method(meth) do |*a, &block|
-            send(:"#{meth}_without_lpc", *a, &block)
+            ret = send(:"#{meth}_without_lpc", *a, &block)
             observer.reinitialize
+            ret
           end
         end
       end

--- a/test/load_path_cache/change_observer_test.rb
+++ b/test/load_path_cache/change_observer_test.rb
@@ -22,12 +22,12 @@ module Bootsnap
         @observer.expects(:push_paths).with(@arr, 'f', 'g')
         @arr.concat(%w(f g))
 
-        @observer.expects(:reinitialize).times(3)
+        @observer.expects(:reinitialize).times(4)
         @arr.delete(3)
         @arr.compact!
         @arr.map!(&:upcase)
-
-        assert_equal(%w(D E A B C F G), @arr)
+        assert_equal('G', @arr.pop)
+        assert_equal(%w(D E A B C F), @arr)
       end
     end
   end


### PR DESCRIPTION
I was playing with using ChangeObserver on $LOADED_FEATURES and noticed that the `pop` method wasn't wrapped, so added the following methods that I noticed were missing:
* `[]=`
* `clear`
* `keep_if`
* `pop`
* `replace`
* `rotate!`
* `uniq!`

I also noticed that the return value of `observer.reinitialize` was being returned, so fixed it to return the value from the wrapped method.