### PR TITLE
Implement ChangeObserver by extending a module into an array

### DIFF
--- a/test/load_path_cache/change_observer_test.rb
+++ b/test/load_path_cache/change_observer_test.rb
@@ -29,6 +29,14 @@ module Bootsnap
         assert_equal('G', @arr.pop)
         assert_equal(%w(D E A B C F), @arr)
       end
+
+      def test_register_twice_observes_once
+        ChangeObserver.register(@observer, @arr)
+
+        @observer.expects(:push_paths).with(@arr, 'a').once
+        @arr << 'a'
+        assert_equal(%w(a), @arr)
+      end
     end
   end
 end


### PR DESCRIPTION
I believe this refactoring makes the code clearer, since we can just use `super` and don't have to handle aliased methods.  Also, extending a module into an object twice doesn't wrap the methods twice, so it naturally handles the case where an observer is registered on an array twice.