### PR TITLE
Add warning message on setup_disable_trace when ruby version is not allowed

### DIFF
--- a/lib/bootsnap.rb
+++ b/lib/bootsnap.rb
@@ -35,6 +35,10 @@ module Bootsnap
   end
 
   def self.setup_disable_trace
-    RubyVM::InstructionSequence.compile_option = { trace_instruction: false }
+    if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.5.0')
+      warn("This method is not allowed with this Ruby version. current: #{RUBY_VERSION}, allowed version: < 2.5.0")
+    else
+      RubyVM::InstructionSequence.compile_option = { trace_instruction: false }
+    end
   end
 end


### PR DESCRIPTION
The `trace_instruction` option on RubyVM::InstructionSequence is removed over Ruby 2.5.0.

* https://github.com/ruby/ruby/commit/cbac40b3e53efce7740899c77eb979008dc96ff5
* https://bugs.ruby-lang.org/issues/14104

With this pullrequest, if ruby version is over 2.5.0, when the `setup_disable_trace` method called, it displays warning message, that is `this method is not allowed'