### PR TITLE
Fix symlinks inside subdirectories not followed

### DIFF
--- a/lib/bootsnap/load_path_cache/path_scanner.rb
+++ b/lib/bootsnap/load_path_cache/path_scanner.rb
@@ -6,13 +6,13 @@ module Bootsnap
       # Glob pattern to find requirable files and subdirectories in given path.
       # It expands to:
       #
-      #   * `/*{.rb,.so,/}` - It matches requirable files, directories and
-      #     symlinks to directories at given path.
-      #   * `/*/**/*{.rb,.so,/}` - It matches requirable files and
+      #   * `/**/*{.rb,.so,/}` - It matches requirable files, directories and
+      #     symlinks to directories at given path any directory tree depth.
+      #   * `/**/*/**/*{.rb,.so,/}` - It matches requirable files and
       #     subdirectories in any (even symlinked) directory at given path at
       #     any directory tree depth.
       #
-      REQUIRABLES_AND_DIRS = "/{,*/**/}*{#{DOT_RB},#{DL_EXTENSIONS.join(',')},/}"
+      REQUIRABLES_AND_DIRS = "/**/{,*/**/}*{#{DOT_RB},#{DL_EXTENSIONS.join(',')},/}"
       NORMALIZE_NATIVE_EXTENSIONS = !DL_EXTENSIONS.include?(LoadPathCache::DOT_SO)
       ALTERNATIVE_NATIVE_EXTENSIONS_PATTERN = /\.(o|bundle|dylib)\z/
       BUNDLE_PATH = Bootsnap.bundler? ?
@@ -45,7 +45,7 @@ module Bootsnap
           end
         end
 
-        [requirables, dirs]
+        [requirables.uniq, dirs.uniq]
       end
     end
   end

--- a/lib/bootsnap/load_path_cache/path_scanner.rb
+++ b/lib/bootsnap/load_path_cache/path_scanner.rb
@@ -3,7 +3,7 @@ require_relative '../explicit_require'
 module Bootsnap
   module LoadPathCache
     module PathScanner
-      ALL_FILES = "/**/{,*/**/}*"
+      ALL_FILES = "/{,**/*/**/}*"
       REQUIRABLE_EXTENSIONS = [DOT_RB] + DL_EXTENSIONS
       NORMALIZE_NATIVE_EXTENSIONS = !DL_EXTENSIONS.include?(LoadPathCache::DOT_SO)
       ALTERNATIVE_NATIVE_EXTENSIONS_PATTERN = /\.(o|bundle|dylib)\z/
@@ -37,7 +37,7 @@ module Bootsnap
           end
         end
 
-        [requirables.uniq, dirs.uniq]
+        [requirables, dirs]
       end
     end
   end

--- a/lib/bootsnap/load_path_cache/path_scanner.rb
+++ b/lib/bootsnap/load_path_cache/path_scanner.rb
@@ -3,16 +3,8 @@ require_relative '../explicit_require'
 module Bootsnap
   module LoadPathCache
     module PathScanner
-      # Glob pattern to find requirable files and subdirectories in given path.
-      # It expands to:
-      #
-      #   * `/**/*{.rb,.so,/}` - It matches requirable files, directories and
-      #     symlinks to directories at given path any directory tree depth.
-      #   * `/**/*/**/*{.rb,.so,/}` - It matches requirable files and
-      #     subdirectories in any (even symlinked) directory at given path at
-      #     any directory tree depth.
-      #
-      REQUIRABLES_AND_DIRS = "/**/{,*/**/}*{#{DOT_RB},#{DL_EXTENSIONS.join(',')},/}"
+      ALL_FILES = "/**/{,*/**/}*"
+      REQUIRABLE_EXTENSIONS = [DOT_RB] + DL_EXTENSIONS
       NORMALIZE_NATIVE_EXTENSIONS = !DL_EXTENSIONS.include?(LoadPathCache::DOT_SO)
       ALTERNATIVE_NATIVE_EXTENSIONS_PATTERN = /\.(o|bundle|dylib)\z/
       BUNDLE_PATH = Bootsnap.bundler? ?
@@ -34,13 +26,13 @@ module Bootsnap
         dirs = []
         requirables = []
 
-        Dir.glob(path + REQUIRABLES_AND_DIRS).each do |absolute_path|
+        Dir.glob(path + ALL_FILES).each do |absolute_path|
           next if contains_bundle_path && absolute_path.start_with?(BUNDLE_PATH)
-          relative_path = absolute_path.slice!(relative_slice)
+          relative_path = absolute_path.slice(relative_slice)
 
-          if relative_path.end_with?('/')
-            dirs << relative_path[0..-2]
-          else
+          if File.directory?(absolute_path)
+            dirs << relative_path
+          elsif REQUIRABLE_EXTENSIONS.include?(File.extname(relative_path))
             requirables << relative_path
           end
         end

--- a/test/load_path_cache/path_scanner_test.rb
+++ b/test/load_path_cache/path_scanner_test.rb
@@ -11,17 +11,21 @@ module Bootsnap
           FileUtils.mkdir_p("#{dir}/ruby/a")
           FileUtils.mkdir_p("#{dir}/ruby/b/c")
           FileUtils.mkdir_p("#{dir}/support/h/i")
+          FileUtils.mkdir_p("#{dir}/ruby/l")
+          FileUtils.mkdir_p("#{dir}/support/l/m")
           FileUtils.touch("#{dir}/ruby/d.rb")
           FileUtils.touch("#{dir}/ruby/e.#{DLEXT}")
           FileUtils.touch("#{dir}/ruby/f.#{OTHER_DLEXT}")
           FileUtils.touch("#{dir}/ruby/a/g.rb")
           FileUtils.touch("#{dir}/support/h/j.rb")
           FileUtils.touch("#{dir}/support/h/i/k.rb")
+          FileUtils.touch("#{dir}/support/l/m/n.rb")
           FileUtils.ln_s("#{dir}/support/h", "#{dir}/ruby/h")
+          FileUtils.ln_s("#{dir}/support/l/m", "#{dir}/ruby/l/m")
 
           entries, dirs = PathScanner.call("#{dir}/ruby")
-          assert_equal(["a/g.rb", "d.rb", "e.#{DLEXT}", "h/i/k.rb", "h/j.rb"], entries.sort)
-          assert_equal(["a", "b", "b/c", "h", "h/i"], dirs.sort)
+          assert_equal(["a/g.rb", "d.rb", "e.#{DLEXT}", "h/i/k.rb", "h/j.rb", "l/m/n.rb"], entries.sort)
+          assert_equal(["a", "b", "b/c", "h", "h/i", "l", "l/m"], dirs.sort)
         end
       end
     end


### PR DESCRIPTION
Symbolic links directly under path have been followed. But symbolic links inside subdirectories have not been followed.

When the structure is:

```
├── path
│   ├── a -> ../support/a
│   ├── c
│   │   └── d -> ../../support/c/d
│   └── f
│       └── g
│           └── h.rb
└── support
    ├── a
    │   └── b.rb
    └── c
        └── d
            └── e.rb
```

Current glob does not include `path/c/d/e.rb`.

```ruby
Dir.glob("path/{,*/**}/*.rb")
#=> ["path/a/b.rb", "path/f/g/h.rb"]
```

So, Let glob follow symbolic link like below:

```ruby
Dir.glob("path/**/{,*/**}/*.rb")
#=> ["path/f/g/h.rb", "path/a/b.rb", "path/c/d/e.rb", "path/f/g/h.rb"]
```

This will make some duplicated entries, so we need to make it unique.

```ruby
Dir.glob("path/**/{,*/**}/*.rb").uniq
#=> ["path/f/g/h.rb", "path/a/b.rb", "path/c/d/e.rb"]
```