### PR TITLE
Fix spring + bootsnap autoload behavior when two similarly named files exist

### DIFF
--- a/lib/bootsnap/load_path_cache/loaded_features_index.rb
+++ b/lib/bootsnap/load_path_cache/loaded_features_index.rb
@@ -84,7 +84,7 @@ module Bootsnap
 
       private
 
-      STRIP_EXTENSION = /\..*?$/
+      STRIP_EXTENSION = /\.[^.]*?$/
       private_constant :STRIP_EXTENSION
 
       def strip_extension(f)


### PR DESCRIPTION
Hi, thanks a bunch for this gem! It's been a life saver for us.

We've been dealing with a mysterious `spring` code reload error when we've got Bootsnap active at the same time.

```
LoadError:
  Unable to autoload constant Inquiries::MessageMailer, expected /project/app/concepts/inquiries/message_mailer.rb to define it
```

The reason for this autoload error was stemming from us having a file named `message_mailer.shared_examples.rb` next to the `message_mailer.rb` file. In our rspec test setup, we've globbed through all `*.shared_examples.rb` files and called `require the_absolute_path` on them.

<blockquote>
<details>
<summary><i>Aside: Background on why we have these files next to each other</i></summary>

<br>
Two architectural things here:

- We have separated Ruby code by "concepts" into `app/concepts/XYZ`
- We write specs next to our app code, e.g. `models/foo.rb` spec would be in `models/foo.spec.rb`

This is a similar approach we've taken to organize our frontend JS code, and that approach has worked splendidly for us.

We knew from the start that this approach is controversial and we might get some strange errors from various places because of this. Nevertheless, we thought that this would be a cost worth paying for cleaner separation of different features.

This is how we did it:

We monkey-patched Rails' eager loading to skip loading files that end in `.spec.rb` or `.shared_examples.rb` with this code in `config/application.rb`:

```rb
# TODO: Extract this monkey-patching to a gem
module EagerLoadWithoutSpecsOrSharedExamples
  # Monkeypatch for Rails' eager loading logic to skip loading files ending with
  # spec file names. This allows specs to reside closer to the implementation
  def eager_load!
    config.eager_load_paths.each do |load_path|
      matcher = %r{\A#{Regexp.escape(load_path.to_s)}/(.*)\.rb\Z}
      loadable_files = (
        Dir.glob("#{load_path}/**/*.rb").sort -
        Dir.glob("#{load_path}/**/*.{spec,shared_examples}.rb").sort
      )

      loadable_files.each do |file|
        require_dependency file.sub(matcher, '\1')
      end
    end
  end
end

module Rails
  class Engine
    prepend EagerLoadWithoutSpecsOrSharedExamples
  end
end
```

We've configured RSpec to automatically load these `.shared_examples.rb` files during start and to find tests with the pattern matching these `.spec.rb` files:

```rb
# spec/spec_helper.rb

Dir[Rails.root.join('{app,spec}/**/*.shared_examples.rb')].each { |f| require f }

RSpec.configure do |config|
  config.pattern = '**/*.spec.rb'
end
```

For the `app/concepts` directory, we tweaked Rails' `config.eager_load_paths` to include `app/concepts/` similarly to how `app/*` directories were already in there.

And now things work! The following command ran specs that were written next to the feature / "concept" called `some_feature`:

```
bin/rspec app/concepts/some_feature
```

</details></blockquote>

Now when we trigger spring to reload code, e.g. doing some change in any controller, the next test run using the constant `Inquiries::MessageMailer` would cause the error I mentioned to pop up.

I was able to trace this back to https://github.com/Shopify/bootsnap/pull/138, where ironically there was even a suggestion to use `File.basename` instead of regex for this constant 😅. It would've worked for us:

```rb
foo = "/path/to/inquiries/message_mailer.shared_examples.rb"
File.join(File.dirname(foo), File.basename(foo, ".*"))
# => "/path/to/inquiries/message_mailer.shared_examples"
foo.sub(/\..*?$/, '')
# => "/path/to/inquiries/message_mailer"
```

---

I glanced at the [LoadedFeatureIndex tests](https://github.com/Shopify/bootsnap/blob/master/test/load_path_cache/loaded_features_index_test.rb) but I wasn't sure what kind of test would be applicable here. I'd love to write a test for this change, if I could get some help with figuring out what kind of test would be good here.

Let me know if you need more details. I'd be happy to help!