### PR TITLE
let YAML.load_path accept File objects

### DIFF
--- a/ext/bootsnap/bootsnap.c
+++ b/ext/bootsnap/bootsnap.c
@@ -269,6 +269,8 @@ cache_key_equal(struct bs_cache_key * k1, struct bs_cache_key * k2)
 static VALUE
 bs_rb_fetch(VALUE self, VALUE cachedir_v, VALUE path_v, VALUE handler)
 {
+  FilePathValue(path_v);
+
   Check_Type(cachedir_v, T_STRING);
   Check_Type(path_v, T_STRING);
 

--- a/lib/bootsnap/compile_cache/yaml.rb
+++ b/lib/bootsnap/compile_cache/yaml.rb
@@ -48,7 +48,7 @@ module Bootsnap
         klass.send(:define_method, :load_file) do |path|
           Bootsnap::CompileCache::Native.fetch(
             cache_dir,
-            path.to_s,
+            path,
             Bootsnap::CompileCache::YAML
           )
         end


### PR DESCRIPTION

Hi, thank you for this awesome gem!

After using bootsnap (which makes our app booting AMAZINGLY fast 😃), we realized that the interface of YAML.load_file gets slightly different from what [ruby provides](https://github.com/ruby/ruby/blob/4e0a512972cdcbfcd5279f1a2a81ba342ed75b6e/spec/ruby/optional/capi/file_spec.rb#L71-L87):

## reproduction case

For instance, the below error occurs only when we set `compile_cache_yaml` option true.

```ruby
> YAML.load_file File.new('/path/to/sample.yml')
Errno::ENOENT: No such file or directory - bs_fetch:open_current_file:open
from /my-home-directory/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/bootsnap-1.3.1/lib/bootsnap/compile_cache/yaml.rb:49:in `fetch'
```

This PR is intended at fixing it.

* Related issues and discussions are also found [here](https://github.com/Shopify/bootsnap/issues/124)

## where the difference comes from

With ruby, (if I understand correctly) non-string path objects are firstly challenged with `to_path` method, and falls back to to_s (to_sym) - starts [here](https://github.com/ruby/ruby/blob/4e0a512972cdcbfcd5279f1a2a81ba342ed75b6e/include/ruby/ruby.h#L595-L596) upto [here](https://github.com/ruby/ruby/blob/4e0a512972cdcbfcd5279f1a2a81ba342ed75b6e/file.c#L172-L188)

WIth bootsnap `to_s` is applied for arguments, so when we put an arbitrary object (like a File instance above), it could be interpreted as something like "#<File:0x00007fa040cc57d0>" before passed to `bs_rb_fetch`, and thus fails when being loaded.

Hope this contribution makes senses.
(and again, a big thanks for providing this fantastic mechanism to us!)
