### PR TITLE
Make bundler? false if Bundler isn't defined

### DIFF
--- a/lib/bootsnap/bundler.rb
+++ b/lib/bootsnap/bundler.rb
@@ -2,11 +2,13 @@ module Bootsnap
   module_function
 
   def bundler?
+    return false unless defined?(::Bundler)
+
     # Bundler environment variable
     ['BUNDLE_BIN_PATH', 'BUNDLE_GEMFILE'].each do |current|
       return true if ENV.key?(current)
     end
-    
+
     false
   end
 end


### PR DESCRIPTION
Previously, if bundler environment variables were set, but bundler wasn't actually loaded, bootsnap would fail with:

    uninitialized constant Bootsnap::LoadPathCache::PathScanner::Bundler

This simply returns `false` if `::Bundler` isn't defined.