### PR TITLE
Reuse expanded_path when generating index

### DIFF
--- a/lib/bootsnap/load_path_cache/cache.rb
+++ b/lib/bootsnap/load_path_cache/cache.rb
@@ -132,10 +132,11 @@ module Bootsnap
             p = Path.new(path)
             @has_relative_paths = true if p.relative?
             next if p.non_directory?
+            expanded_path = p.expanded_path
             entries, dirs = p.entries_and_dirs(@store)
             # push -> low precedence -> set only if unset
             dirs.each    { |dir| @dirs[dir]  ||= true }
-            entries.each { |rel| @index[rel] ||= p.expanded_path }
+            entries.each { |rel| @index[rel] ||= expanded_path }
           end
         end
       end
@@ -145,10 +146,11 @@ module Bootsnap
           paths.map(&:to_s).reverse_each do |path|
             p = Path.new(path)
             next if p.non_directory?
+            expanded_path = p.expanded_path
             entries, dirs = p.entries_and_dirs(@store)
             # unshift -> high precedence -> unconditional set
             dirs.each    { |dir| @dirs[dir]  = true }
-            entries.each { |rel| @index[rel] = p.expanded_path }
+            entries.each { |rel| @index[rel] = expanded_path }
           end
         end
       end


### PR DESCRIPTION
Previously we were calling `Path#expanded_path` (which calls `File.expand_path`) for each entry we would put into the index. This would expand and create a copy of the path string for each file.

This commit stores the expanded path in a local, and reuses it for each entry in the index `Hash`. This should be faster and use less memory.