### PR TITLE
Add special case for uniq! in ChangeObserver

### DIFF
--- a/lib/bootsnap/load_path_cache/change_observer.rb
+++ b/lib/bootsnap/load_path_cache/change_observer.rb
@@ -25,6 +25,14 @@ module Bootsnap
           super
         end
 
+        # uniq! keeps the first occurance of each path, otherwise preserving
+        # order, preserving the effective load path
+        def uniq!
+          ret = super
+          @lpc_observer.reinitialize if block_given?
+          ret
+        end
+
         # For each method that modifies the array more aggressively, override
         # the method to also have the observer completely reconstruct its state
         # after the modification. Many of these could be made to modify the
@@ -34,7 +42,7 @@ module Bootsnap
         %i(
           []= clear collect! compact! delete delete_at delete_if fill flatten!
           insert keep_if map! pop reject! replace reverse! rotate! select!
-          shift shuffle! slice! sort! sort_by! uniq!
+          shift shuffle! slice! sort! sort_by!
         ).each do |method_name|
           define_method(method_name) do |*args, &block|
             ret = super(*args, &block)

--- a/lib/bootsnap/load_path_cache/change_observer.rb
+++ b/lib/bootsnap/load_path_cache/change_observer.rb
@@ -27,9 +27,9 @@ module Bootsnap
 
         # uniq! keeps the first occurance of each path, otherwise preserving
         # order, preserving the effective load path
-        def uniq!
+        def uniq!(*args)
           ret = super
-          @lpc_observer.reinitialize if block_given?
+          @lpc_observer.reinitialize if block_given? || !args.empty?
           ret
         end
 

--- a/test/load_path_cache/change_observer_test.rb
+++ b/test/load_path_cache/change_observer_test.rb
@@ -37,6 +37,16 @@ module Bootsnap
         @arr << 'a'
         assert_equal(%w(a), @arr)
       end
+
+      def test_uniq_without_block
+        @observer.expects(:reinitialize).never
+        @arr.uniq!
+      end
+
+      def test_uniq_with_block
+        @observer.expects(:reinitialize).once
+        @arr.uniq! {}
+      end
     end
   end
 end


### PR DESCRIPTION
`uniq!` does not change the effective load order. The first occurrence of each path is kept, with order preserved. So we shouldn't need to reinitialize after calling it.

This is desirable because `$LOAD_PATH.uniq!` is [called by Rails](https://github.com/rails/rails/blob/5bd4a4c78b43f25245d3597876f541d84782ecc7/railties/lib/rails/engine.rb#L559).