### PR TITLE
Avoid exponential retries of load_missing_constant on a NameError

### DIFF
--- a/lib/bootsnap/load_path_cache/core_ext/active_support.rb
+++ b/lib/bootsnap/load_path_cache/core_ext/active_support.rb
@@ -42,6 +42,8 @@ module Bootsnap
           def load_missing_constant(from_mod, const_name)
             super
           rescue NameError => e
+            # If we already had cache disabled, there's no use retrying
+            raise if Thread.current[:without_bootsnap_cache]
             # NoMethodError is a NameError, but we only want to handle actual
             # NameError instances.
             raise unless e.class == NameError
@@ -58,6 +60,8 @@ module Bootsnap
           def depend_on(*)
             super
           rescue LoadError
+            # If we already had cache disabled, there's no use retrying
+            raise if Thread.current[:without_bootsnap_cache]
             CoreExt::ActiveSupport.without_bootsnap_cache { super }
           end
         end


### PR DESCRIPTION
This should fix #142

The underlying load_missing_constant implementation will call itself recursively (through const_missing). If the constant can't be loaded at all, the retries will make this exponential - `O(2 ** module_depth)` 😱.

This PR makes it linear, now calling `search_for_file` only 2x as much as without bootsnap. We do this by setting a thread-local variable inside load_missing_constant to disable retries. This variable is unset in `require_or_load` so that missing constants being loaded from the required file are again attempted cached.

## Calls to search_for_file

``` ruby
ActiveSupport::Dependencies.singleton_class.prepend Module.new {
  def search_for_file(path)
    puts path
    super
  end
}

module Quux; module Quuux; module Quuuux; end; end; end

Quux::Quuux::Quuuux::SomeClassIDontHave
```

### Before (30 Calls)

```
quux/quuux/quuuux/some_class_i_dont_have
quux/quuux/some_class_i_dont_have
quux/some_class_i_dont_have
some_class_i_dont_have
some_class_i_dont_have
quux/some_class_i_dont_have
some_class_i_dont_have
some_class_i_dont_have
quux/quuux/some_class_i_dont_have
quux/some_class_i_dont_have
some_class_i_dont_have
some_class_i_dont_have
quux/some_class_i_dont_have
some_class_i_dont_have
some_class_i_dont_have
quux/quuux/quuuux/some_class_i_dont_have
quux/quuux/some_class_i_dont_have
quux/some_class_i_dont_have
some_class_i_dont_have
some_class_i_dont_have
quux/some_class_i_dont_have
some_class_i_dont_have
some_class_i_dont_have
quux/quuux/some_class_i_dont_have
quux/some_class_i_dont_have
some_class_i_dont_have
some_class_i_dont_have
quux/some_class_i_dont_have
some_class_i_dont_have
some_class_i_dont_have
```

### After (8 calls)
```
quux/quuux/quuuux/some_class_i_dont_have
quux/quuux/some_class_i_dont_have
quux/some_class_i_dont_have
some_class_i_dont_have
quux/quuux/quuuux/some_class_i_dont_have
quux/quuux/some_class_i_dont_have
quux/some_class_i_dont_have
some_class_i_dont_have
```

## 📈 Graph!

I can't help but make a graph!

Module nesting | no bootsnap | old | no nested retry | only top level retry
-- | -- | -- | -- | --
0 | 1 | 2 | 2 | 2
1 | 2 | 6 | 5 | 4
2 | 3 | 14 | 9 | 6
3 | 4 | 30 | 14 | 8
4 | 5 | 62 | 20 | 10
5 | 6 | 126 | 27 | 12
6 | 7 | 254 | 35 | 14
7 | 8 | 510 | 44 | 16
8 | 9 | 1022 | 54 | 18
9 | 10 | 2046 | 65 | 20


![chart](https://user-images.githubusercontent.com/131752/45189230-cdec1700-b1ec-11e8-8b26-6b8d2abe61c3.png)
