### PR TITLE
Fix the API for ActiveSupport::Dependencies#autoloadable_module?

### DIFF
--- a/lib/bootsnap/load_path_cache/cache.rb
+++ b/lib/bootsnap/load_path_cache/cache.rb
@@ -14,10 +14,10 @@ module Bootsnap
         reinitialize
       end
 
-      # Does this directory exist as a child of one of the path items?
-      # e.g. given "/a/b/c/d" exists, and the path is ["/a/b"], has_dir?("c/d")
-      # is true.
-      def has_dir?(dir)
+      # What is the path item that contains the dir as child?
+      # e.g. given "/a/b/c/d" exists, and the path is ["/a/b"], load_dir("c/d")
+      # is "/a/b".
+      def load_dir(dir)
         reinitialize if stale?
         @mutex.synchronize { @dirs[dir] }
       end
@@ -108,7 +108,7 @@ module Bootsnap
           @path_obj = path_obj
           ChangeObserver.register(self, @path_obj)
           @index = {}
-          @dirs = Hash.new(false)
+          @dirs = {}
           @generated_at = now
           push_paths_locked(*@path_obj)
         end
@@ -135,7 +135,7 @@ module Bootsnap
             expanded_path = p.expanded_path
             entries, dirs = p.entries_and_dirs(@store)
             # push -> low precedence -> set only if unset
-            dirs.each    { |dir| @dirs[dir]  ||= true }
+            dirs.each    { |dir| @dirs[dir]  ||= path }
             entries.each { |rel| @index[rel] ||= expanded_path }
           end
         end
@@ -149,7 +149,7 @@ module Bootsnap
             expanded_path = p.expanded_path
             entries, dirs = p.entries_and_dirs(@store)
             # unshift -> high precedence -> unconditional set
-            dirs.each    { |dir| @dirs[dir]  = true }
+            dirs.each    { |dir| @dirs[dir]  = path }
             entries.each { |rel| @index[rel] = expanded_path }
           end
         end

--- a/lib/bootsnap/load_path_cache/core_ext/active_support.rb
+++ b/lib/bootsnap/load_path_cache/core_ext/active_support.rb
@@ -34,7 +34,7 @@ module Bootsnap
           end
 
           def autoloadable_module?(path_suffix)
-            Bootsnap::LoadPathCache.autoload_paths_cache.has_dir?(path_suffix)
+            Bootsnap::LoadPathCache.autoload_paths_cache.load_dir(path_suffix)
           end
 
           def remove_constant(const)

--- a/test/load_path_cache/cache_test.rb
+++ b/test/load_path_cache/cache_test.rb
@@ -69,9 +69,9 @@ module Bootsnap
 
       def test_directory_caching
         cache = Cache.new(NullCache, [@dir1])
-        assert cache.has_dir?("foo")
-        assert cache.has_dir?("foo/bar")
-        refute cache.has_dir?("bar")
+        assert_equal @dir1, cache.load_dir("foo")
+        assert_equal @dir1, cache.load_dir("foo/bar")
+        assert_nil cache.load_dir("bar")
       end
 
       def test_extension_permutations


### PR DESCRIPTION
ActiveSupport::Dependencies#autoloadable_module? returns the load path
that contains the argument or nil in case no load path contains that
argument. [[1][1]]

In the bootsnap monkey patch we were changing that return to be true or
false that breaks the API expectation in Rails.

Fixes #197.

[1]: https://github.com/rails/rails/blob/12b32d804996c6bb3d215a22762c0c1a27f223d3/activesupport/lib/active_support/dependencies.rb#L434-L442