### PR TITLE
Implement JRuby path caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ os:
 rvm:
   - ruby-2.4
   - ruby-2.5
+  - jruby-9.2.0.0
+
+matrix:
+  allow_failures:
+    - rvm: jruby-9.2.0.0
 
 before_script: rake
 script: bundle exec bin/testunit


### PR DESCRIPTION
This is an early suggestion to implement path caching for internal libraries for JRuby. JRuby ships with several internal libraries in jar files which bootsnap can will not find on the filesystem. In this case, we should fall back to original require / load. ``JRuby::Util.internal_libraries`` returns a list of these internal libraries.

It seems that loading is now working, however, starting of a basic Rails app is still broken because Puma fails to load socket (although the socket library seems to get loaded). It fails with this error message:

```
Bundler::GemRequireError: There was an error while trying to load the gem 'puma'.
Gem Load Error is: uninitialized constant IPSocket
```

Also there is currently also a hack for some paths which include ``.java.rb`` extension, I wasn't able to figure out where bootsnap is producing these paths yet. Would be glad for some pointers that we might can get rid of this hack (``normalize_feature`` method).

I think this patch is almost working and only some minior tweaks are necessary. Would be glad for some pointers and suggestions.

Fix https://github.com/Shopify/bootsnap/issues/162

cc @headius @kares 

// Edit:
Rails version: 5.2.1 with manually enabled bootsnap
Bootsnap master (5d1b932c95e654056969d86accfda8d2b5afc735) with this patch applied