### PR TITLE
Check that cache_dir is writable before using it.

### DIFF
--- a/lib/bootsnap/setup.rb
+++ b/lib/bootsnap/setup.rb
@@ -30,6 +30,18 @@ unless cache_dir
   cache_dir = File.join(app_root, 'tmp', 'cache')
 end
 
+begin
+  File.mkpath(cache_dir)
+rescue
+  # Ignore errors. If we couldn't mkpath, then writable? will return false below.
+end
+if !File.writable?(cache_dir)
+  $stderr.puts "[bootsnap/setup] cache directory #{cache_dir} doesn't exist or is not writable."
+  $stderr.puts "[bootsnap/setup] An alternative directory can be specified with the environment variable BOOTSNAP_CACHE_DIR"
+
+  raise "can't write to bootsnap cache directory"
+end
+
 Bootsnap.setup(
   cache_dir:            cache_dir,
   development_mode:     development_mode,


### PR DESCRIPTION
When including 'bootsnap/setup', check that the detected or specified
cache directory is writable. If it isn't, print a message to stderr
explaining that it can be overridden with BOOTSNAP_CACHE_DIR.

Before:
$ BOOTSNAP_CACHE_DIR=/bootsnap rails c
Traceback (most recent call last):
...
ruby-2.5.1/lib/ruby/2.5.0/fileutils.rb:232:in `mkdir': Permission denied @ dir_s_mkdir - /bootsnap (Errno::EACCES)

After:
$ BOOTSNAP_CACHE_DIR=/bootsnap rails c
[bootsnap/setup] cache directory /bootsnap doesn't exist or is not writable.
[bootsnap/setup] An alternative directory can be specified with the environment variable BOOTSNAP_CACHE_DIR
Traceback (most recent call last):
...
bootsnap/lib/bootsnap/setup.rb:42:in `<top (required)>': can't write to bootsnap cache directory