### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/bootsnap.gemspec
+++ b/bootsnap.gemspec
@@ -15,6 +15,12 @@ Gem::Specification.new do |spec|
   spec.description   = spec.summary
   spec.homepage      = "https://github.com/Shopify/bootsnap"
 
+  spec.metadata = {
+    'bug_tracker_uri'   => 'https://github.com/Shopify/bootsnap/issues',
+    'changelog_uri'     => 'https://github.com/Shopify/bootsnap/blob/master/CHANGELOG.md',
+    'source_code_uri'   => 'https://github.com/Shopify/bootsnap',
+  }
+
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end


### PR DESCRIPTION
Add [project metadata](https://guides.rubygems.org/specification-reference/#metadata) to the gemspec file. This'll allow people to more easily access the source code, raise issues, and analyse the changelog. These links will appear on the rubygems page at https://rubygems.org/gems/bootsnap after the next release.