### PR TITLE
Test ruby-head with allow_failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ os:
 rvm:
   - ruby-2.4
   - ruby-2.5
+  - ruby-head
+
+matrix:
+  allow_failures:
+    - rvm: ruby-head
 
 before_script: rake
 script: bundle exec bin/testunit


### PR DESCRIPTION
Sometimes Ruby trunk crashes on bootsnap. 

I think it would be nice if we can notice trunk's change which is harmful for bootsnap earlier by this.