### PR TITLE
Make bootsnap/setup a noop on unsupported ruby implementations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,15 @@ rvm:
 matrix:
   allow_failures:
     - rvm: ruby-head
+  include:
+    - rvm: jruby
+      os: linux
+      env: MINIMAL_SUPPORT=1
+    # Truffle 1.0.0-rc12 should be able to pass:
+    # https://github.com/oracle/truffleruby/issues/1400#issuecomment-456166426
+    # It will be release early Feb 2019
+    # - rvm: truffleruby
+    #   os: linux
+    #   env: MINIMAL_SUPPORT=1
 
-before_script: rake
-script: bundle exec bin/testunit
+script: bin/ci

--- a/bin/ci
+++ b/bin/ci
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+if [[ "${MINIMAL_SUPPORT-0}" -eq 1 ]]; then
+  exec bin/test-minimal-support
+else
+  rake
+  exec bin/testunit
+fi

--- a/bin/test-minimal-support
+++ b/bin/test-minimal-support
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+cd test/minimal_support
+bundle
+BOOTSNAP_CACHE_DIR=/tmp bundle exec ruby -I ../../lib bootsnap_setup.rb

--- a/bootsnap.gemspec
+++ b/bootsnap.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
     spec.extensions  = ['ext/bootsnap/extconf.rb']
   end
 
-  spec.add_development_dependency "bundler", '~> 1'
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rake-compiler', '~> 0'
   spec.add_development_dependency "minitest", "~> 5.0"

--- a/lib/bootsnap/compile_cache.rb
+++ b/lib/bootsnap/compile_cache.rb
@@ -2,14 +2,29 @@ module Bootsnap
   module CompileCache
     def self.setup(cache_dir:, iseq:, yaml:)
       if iseq
-        require_relative 'compile_cache/iseq'
-        Bootsnap::CompileCache::ISeq.install!(cache_dir)
+        if supported?
+          require_relative 'compile_cache/iseq'
+          Bootsnap::CompileCache::ISeq.install!(cache_dir)
+        else
+          $stderr.puts "[bootsnap/setup] bytecode caching is not supported on this implementation of Ruby"
+        end
       end
 
       if yaml
-        require_relative 'compile_cache/yaml'
-        Bootsnap::CompileCache::YAML.install!(cache_dir)
+        if supported?
+          require_relative 'compile_cache/yaml'
+          Bootsnap::CompileCache::YAML.install!(cache_dir)
+        else
+          $stderr.puts "[bootsnap/setup] YAML parsing caching is not supported on this implementation of Ruby"
+        end
       end
+    end
+
+    def self.supported?
+      # only enable on 'ruby' (MRI), POSIX (darwin, linux, *bsd), and >= 2.3.0
+      RUBY_ENGINE == 'ruby' &&
+      RUBY_PLATFORM =~ /darwin|linux|bsd/ &&
+      Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.3.0")
     end
   end
 end

--- a/lib/bootsnap/load_path_cache.rb
+++ b/lib/bootsnap/load_path_cache.rb
@@ -25,6 +25,11 @@ module Bootsnap
                   :loaded_features_index, :realpath_cache
 
       def setup(cache_path:, development_mode:, active_support: true)
+        unless supported?
+          $stderr.puts "[bootsnap/setup] Load path caching is not supported on this implementation of Ruby"
+          return
+        end
+
         store = Store.new(cache_path)
 
         @loaded_features_index = LoadedFeaturesIndex.new
@@ -44,6 +49,11 @@ module Bootsnap
           )
           require_relative 'load_path_cache/core_ext/active_support'
         end
+      end
+
+      def supported?
+        RUBY_ENGINE == 'ruby' &&
+        RUBY_PLATFORM =~ /darwin|linux|bsd/
       end
     end
   end

--- a/lib/bootsnap/setup.rb
+++ b/lib/bootsnap/setup.rb
@@ -3,12 +3,6 @@ require_relative '../bootsnap'
 env = ENV['RAILS_ENV'] || ENV['RACK_ENV'] || ENV['ENV']
 development_mode = ['', nil, 'development'].include?(env)
 
-# only enable on 'ruby' (MRI), POSIX (darwin, linux, *bsd), and >= 2.3.0
-enable_cc =
-  RUBY_ENGINE == 'ruby' &&
-  RUBY_PLATFORM =~ /darwin|linux|bsd/ &&
-  Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.3.0")
-
 cache_dir = ENV['BOOTSNAP_CACHE_DIR']
 unless cache_dir
   config_dir_frame = caller.detect do |line|
@@ -36,6 +30,6 @@ Bootsnap.setup(
   load_path_cache:      true,
   autoload_paths_cache: true, # assume rails. open to PRs to impl. detection
   disable_trace:        false,
-  compile_cache_iseq:   enable_cc,
-  compile_cache_yaml:   enable_cc
+  compile_cache_iseq:   true,
+  compile_cache_yaml:   true,
 )

--- a/test/minimal_support/bootsnap_setup.rb
+++ b/test/minimal_support/bootsnap_setup.rb
@@ -1,0 +1,2 @@
+require 'bundler/setup'
+require 'bootsnap/setup'


### PR DESCRIPTION
### Context

We (Shopify) don't really want to maintain support for alternative implementations of Ruby because it requires quite a lot of knowledge of the platforms and have a tendency to fail often.

However bootsnap is currently a burden to them, because they often try to test their compatibility with existing Rails apps (e.g. Discourse) and bootsnap prevent from doing that without modifying the app.

### Proposal

We don't actually have to implement & test load path caching or ISeq caching on JRuby / Truffle / Rubinius, we can simply make sure Bootsnap acts as a noop on these alternative implementations.

This is what this PR attempt to do.

cc @eregon