### PR TITLE
Rescue ENOTDIR when already rescuing ENOENT

### DIFF
--- a/lib/bootsnap/load_path_cache/path.rb
+++ b/lib/bootsnap/load_path_cache/path.rb
@@ -26,7 +26,7 @@ module Bootsnap
       # True if the path exists, but represents a non-directory object
       def non_directory?
         !File.stat(path).directory?
-      rescue Errno::ENOENT
+      rescue Errno::ENOENT, Errno::ENOTDIR
         false
       end
 
@@ -76,7 +76,7 @@ module Bootsnap
         ["", *dirs].each do |dir|
           curr = begin
             File.mtime("#{path}/#{dir}").to_i
-          rescue Errno::ENOENT
+          rescue Errno::ENOENT, Errno::ENOTDIR
             -1
           end
           max = curr if curr > max


### PR DESCRIPTION
This morning when building my application I encountered the next issue:

```
/Users/ody/.rvm/gems/ruby-2.4.4@repo/gems/bootsnap-1.3.2/lib/bootsnap/load_path_cache/path.rb:28:in `stat': Not a directory @ rb_file_s_stat - /path/to/repo/test/mailers/previews (Errno::ENOTDIR)
	from /Users/ody/.rvm/gems/ruby-2.4.4@repo/gems/bootsnap-1.3.2/lib/bootsnap/load_path_cache/path.rb:28:in `non_directory?'
```

After digging a bit with IRB and [some article](https://blog.honeybadger.io/understanding-rubys-strange-errno-exceptions/), I got it that When Trying to get Dir information over a file, the thrown error is not `ENOENT` but `ENOTDIR`. It seems that this behaviour has happened [with the JRuby codebase as well](https://github.com/jruby/jruby/issues/3840).

To stop that all together, I've been rescuing both. I haven't added any test because it is already covered by this one:

https://github.com/Shopify/bootsnap/blob/2390a1a51cc8922ded8ae7aab3f8cf39cdde5847/test/load_path_cache/path_test.rb#L38

Let me know what you think about this,
Cheers