### PR TITLE
Only require load_path_cache files if supported

### DIFF
--- a/lib/bootsnap/load_path_cache.rb
+++ b/lib/bootsnap/load_path_cache.rb
@@ -59,10 +59,12 @@ module Bootsnap
   end
 end
 
-require_relative 'load_path_cache/path_scanner'
-require_relative 'load_path_cache/path'
-require_relative 'load_path_cache/cache'
-require_relative 'load_path_cache/store'
-require_relative 'load_path_cache/change_observer'
-require_relative 'load_path_cache/loaded_features_index'
-require_relative 'load_path_cache/realpath_cache'
+if Bootsnap::LoadPathCache.supported?
+  require_relative 'load_path_cache/path_scanner'
+  require_relative 'load_path_cache/path'
+  require_relative 'load_path_cache/cache'
+  require_relative 'load_path_cache/store'
+  require_relative 'load_path_cache/change_observer'
+  require_relative 'load_path_cache/loaded_features_index'
+  require_relative 'load_path_cache/realpath_cache'
+end


### PR DESCRIPTION
* This saves a bit of time on unsupported implementations and avoids loading fileutils and msgpack when not needed.
* It also works around an issue in TruffleRuby, see https://github.com/oracle/truffleruby/issues/1562

I will fix that issue, but it is too late for the upcoming release (1.0.0-rc12).
I can also confirm `MINIMAL_SUPPORT=1 bin/ci` passes on TruffleRuby with that issue fixed (even before this PR).

Relates to #221.

Do you know if `Bootsnap::ExplicitRequire.from_rubylibdir` is used outside of the single usage in `lib/bootsnap/load_path_cache/store.rb` ? It doesn't seem so from [GitHub code search](https://github.com/search?q=Bootsnap%3A%3AExplicitRequire.from_rubylibdir+-filename%3Astore.rb+-filename%3Aexplicit_require.rb&type=Code).