### PR TITLE
Only warn in verbose mode that caching is disabled

### DIFF
--- a/bin/test-minimal-support
+++ b/bin/test-minimal-support
@@ -4,4 +4,4 @@ set -euxo pipefail
 
 cd test/minimal_support
 bundle
-BOOTSNAP_CACHE_DIR=/tmp bundle exec ruby -I ../../lib bootsnap_setup.rb
+BOOTSNAP_CACHE_DIR=/tmp bundle exec ruby -w -I ../../lib bootsnap_setup.rb

--- a/lib/bootsnap/compile_cache.rb
+++ b/lib/bootsnap/compile_cache.rb
@@ -6,7 +6,7 @@ module Bootsnap
           require_relative 'compile_cache/iseq'
           Bootsnap::CompileCache::ISeq.install!(cache_dir)
         else
-          $stderr.puts "[bootsnap/setup] bytecode caching is not supported on this implementation of Ruby"
+          warn "[bootsnap/setup] bytecode caching is not supported on this implementation of Ruby" if $VERBOSE
         end
       end
 
@@ -15,7 +15,7 @@ module Bootsnap
           require_relative 'compile_cache/yaml'
           Bootsnap::CompileCache::YAML.install!(cache_dir)
         else
-          $stderr.puts "[bootsnap/setup] YAML parsing caching is not supported on this implementation of Ruby"
+          warn "[bootsnap/setup] YAML parsing caching is not supported on this implementation of Ruby" if $VERBOSE
         end
       end
     end

--- a/lib/bootsnap/load_path_cache.rb
+++ b/lib/bootsnap/load_path_cache.rb
@@ -26,7 +26,7 @@ module Bootsnap
 
       def setup(cache_path:, development_mode:, active_support: true)
         unless supported?
-          $stderr.puts "[bootsnap/setup] Load path caching is not supported on this implementation of Ruby"
+          warn "[bootsnap/setup] Load path caching is not supported on this implementation of Ruby" if $VERBOSE
           return
         end
 


### PR DESCRIPTION
* It does not affect semantics and is OK to ignore.
* Warning on every application start would annoy users, and they cannot do much about it.

Relates to #221.
cc @casperisfine