### PR TITLE
Respond to $LOADED_FEATURES.delete by removing from LFI

### DIFF
--- a/lib/bootsnap/load_path_cache.rb
+++ b/lib/bootsnap/load_path_cache.rb
@@ -37,6 +37,7 @@ module Bootsnap
 
         @load_path_cache = Cache.new(store, $LOAD_PATH, development_mode: development_mode)
         require_relative('load_path_cache/core_ext/kernel_require')
+        require_relative('load_path_cache/core_ext/loaded_features')
 
         if active_support
           # this should happen after setting up the initial cache because it

--- a/lib/bootsnap/load_path_cache/cache.rb
+++ b/lib/bootsnap/load_path_cache/cache.rb
@@ -73,7 +73,8 @@ module Bootsnap
             x = search_index(feature[0..-4] + DLEXT)
             return x if x
             if DLEXT2
-              search_index(feature[0..-4] + DLEXT2)
+              x = search_index(feature[0..-4] + DLEXT2)
+              return x if x
             end
           else
             # other, unknown extension. For example, `.rake`. Since we haven't
@@ -81,6 +82,12 @@ module Bootsnap
             raise(LoadPathCache::FallbackScan, '', [])
           end
         end
+
+        # In development mode, we don't want to confidently return failures for
+        # cases where the file doesn't appear to be on the load path. We should
+        # be able to detect newly-created files without rebooting the
+        # application.
+        raise(LoadPathCache::FallbackScan) if @development_mode
       end
 
       if RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/

--- a/lib/bootsnap/load_path_cache/core_ext/loaded_features.rb
+++ b/lib/bootsnap/load_path_cache/core_ext/loaded_features.rb
@@ -1,0 +1,7 @@
+class << $LOADED_FEATURES
+  alias_method(:delete_without_bootsnap, :delete)
+  def delete(key)
+    Bootsnap::LoadPathCache.loaded_features_index.purge(key)
+    delete_without_bootsnap(key)
+  end
+end

--- a/test/load_path_cache/loaded_features_index_test.rb
+++ b/test/load_path_cache/loaded_features_index_test.rb
@@ -51,6 +51,20 @@ module Bootsnap
         refute(@index.key?('foo'))
       end
 
+      def test_purge_loaded_feature
+        refute(@index.key?('bundler'))
+        refute(@index.key?('bundler.rb'))
+        refute(@index.key?('foo'))
+        @index.register('bundler', '/a/b/bundler.rb') {}
+        assert(@index.key?('bundler'))
+        assert(@index.key?('bundler.rb'))
+        refute(@index.key?('foo'))
+        @index.purge('/a/b/bundler.rb')
+        refute(@index.key?('bundler'))
+        refute(@index.key?('bundler.rb'))
+        refute(@index.key?('foo'))
+      end
+
       def test_derives_initial_state_from_loaded_features
         index = LoadedFeaturesIndex.new
         assert(index.key?('minitest/autorun'))


### PR DESCRIPTION
@fxn @rafaelfranca @kaspth this seems to solve the problem, WDYT?

```
bootsnap deletion-lfi > irb -rbootsnap/setup
irb(main):001:0> Bootsnap::LoadPathCache.loaded_features_index.key?('bootsnap')
=> true
irb(main):002:0> x=$LOADED_FEATURES.detect{|x|x=~/bootsnap.rb/}
=> "/Users/burke/.gem/ruby/2.6.0/gems/bootsnap-1.3.2/lib/bootsnap.rb"
irb(main):003:0> $LOADED_FEATURES.delete(x)
=> "/Users/burke/.gem/ruby/2.6.0/gems/bootsnap-1.3.2/lib/bootsnap.rb"
irb(main):004:0> Bootsnap::LoadPathCache.loaded_features_index.key?('bootsnap')
=> false
irb(main):005:0>
```