### PR TITLE
add dependency: rb-readline

### DIFF
--- a/bootsnap.gemspec
+++ b/bootsnap.gemspec
@@ -40,6 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('rake-compiler', '~> 0')
   spec.add_development_dependency("minitest", "~> 5.0")
   spec.add_development_dependency("mocha", "~> 1.2")
+  spec.add_development_dependency("rb-readline", "~> 0.5.5")
 
   spec.add_runtime_dependency("msgpack", "~> 1.0")
 end


### PR DESCRIPTION
To fix this error:
/usr/local/lib/ruby/gems/2.5.0/gems/bootsnap-1.3.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require': cannot load such file -- readline (LoadError)