### PR TITLE
Paper over EACCES from Native.fetch with clearer error:

### DIFF
--- a/lib/bootsnap/compile_cache.rb
+++ b/lib/bootsnap/compile_cache.rb
@@ -1,5 +1,8 @@
 module Bootsnap
   module CompileCache
+    Error           = Class.new(StandardError)
+    PermissionError = Class.new(Error)
+
     def self.setup(cache_dir:, iseq:, yaml:)
       if iseq
         if supported?
@@ -18,6 +21,15 @@ module Bootsnap
           warn("[bootsnap/setup] YAML parsing caching is not supported on this implementation of Ruby")
         end
       end
+    end
+
+    def self.permission_error(path)
+      cpath = Bootsnap::CompileCache::ISeq.cache_dir
+      raise(
+        PermissionError,
+        "bootsnap doesn't have permission to write cache entries in '#{cpath}' " \
+        "(or, less likely, doesn't have permisison to read '#{path}')",
+      )
     end
 
     def self.supported?

--- a/lib/bootsnap/compile_cache/iseq.rb
+++ b/lib/bootsnap/compile_cache/iseq.rb
@@ -39,6 +39,8 @@ module Bootsnap
             path.to_s,
             Bootsnap::CompileCache::ISeq
           )
+        rescue Errno::EACCES
+          Bootsnap::CompileCache.permission_error(path)
         rescue RuntimeError => e
           if e.message =~ /unmatched platform/
             puts("unmatched platform for file #{path}")

--- a/lib/bootsnap/compile_cache/yaml.rb
+++ b/lib/bootsnap/compile_cache/yaml.rb
@@ -46,11 +46,15 @@ module Bootsnap
 
         klass = class << ::YAML; self; end
         klass.send(:define_method, :load_file) do |path|
-          Bootsnap::CompileCache::Native.fetch(
-            cache_dir,
-            path,
-            Bootsnap::CompileCache::YAML
-          )
+          begin
+            Bootsnap::CompileCache::Native.fetch(
+              cache_dir,
+              path,
+              Bootsnap::CompileCache::YAML
+            )
+          rescue Errno::EACCES
+            Bootsnap::CompileCache.permission_error(path)
+          end
         end
       end
     end

--- a/test/compile_cache_test.rb
+++ b/test/compile_cache_test.rb
@@ -27,7 +27,7 @@ class CompileCacheTest < Minitest::Test
     folder = File.dirname(Help.cache_path(@tmp_dir, path))
     FileUtils.mkdir_p(folder)
     FileUtils.chmod(0400, folder)
-    assert_raises(Errno::EACCES) { load(path) }
+    assert_raises(Bootsnap::CompileCache::PermissionError) { load(path) }
   end
 
   def test_can_open_read_only_cache


### PR DESCRIPTION
Currently, users get:

    Permission denied - bs_fetch:atomic_write_cache_file:open.

This is not actionable: it doesn't even include the path which was
denied access. Here we at least present the paths we failed on.

* [fixes #171]