### PR TITLE
Handle another "corrupted data" case:

### DIFF
--- a/lib/bootsnap/load_path_cache/store.rb
+++ b/lib/bootsnap/load_path_cache/store.rb
@@ -60,9 +60,11 @@ module Bootsnap
       def load_data
         @data = begin
           MessagePack.load(File.binread(@store_path))
-                # handle malformed data due to upgrade incompatability
-                rescue Errno::ENOENT, MessagePack::MalformedFormatError, MessagePack::UnknownExtTypeError, EOFError
-                  {}
+          # handle malformed data due to upgrade incompatability
+        rescue Errno::ENOENT, MessagePack::MalformedFormatError, MessagePack::UnknownExtTypeError, EOFError
+          {}
+        rescue ArgumentError => e
+          e.message =~ /negative array size/ ? {} : raise
         end
       end
 


### PR DESCRIPTION
MessagePack can fail in a whole bunch of different ways. This one happened on Windows 10 apparently, but I don't have any way to actually debug that. This handling looks pretty well in-line with what we were already doing.

* [fixes #187]