### PR TITLE
expand_path correctly when resolving relative paths:

### DIFF
--- a/lib/bootsnap/load_path_cache/cache.rb
+++ b/lib/bootsnap/load_path_cache/cache.rb
@@ -46,7 +46,7 @@ module Bootsnap
         reinitialize if (@has_relative_paths && dir_changed?) || stale?
         feature = feature.to_s
         return feature if absolute_path?(feature)
-        return File.expand_path(feature) if feature.start_with?('./')
+        return expand_path(feature) if feature.start_with?('./')
         @mutex.synchronize do
           x = search_index(feature)
           return x if x
@@ -162,6 +162,10 @@ module Bootsnap
         end
       end
 
+      def expand_path(feature)
+        maybe_append_extension(File.expand_path(feature))
+      end
+
       def stale?
         @development_mode && @generated_at + AGE_THRESHOLD < now
       end
@@ -174,9 +178,17 @@ module Bootsnap
         def search_index(f)
           try_index(f + DOT_RB) || try_index(f + DLEXT) || try_index(f + DLEXT2) || try_index(f)
         end
+
+        def maybe_append_extension(f)
+          try_ext(f + DOT_RB) || try_ext(f + DLEXT) || try_ext(f + DLEXT2) || f
+        end
       else
         def search_index(f)
           try_index(f + DOT_RB) || try_index(f + DLEXT) || try_index(f)
+        end
+
+        def maybe_append_extension(f)
+          try_ext(f + DOT_RB) || try_ext(f + DLEXT) || f
         end
       end
 
@@ -184,6 +196,10 @@ module Bootsnap
         if (p = @index[f])
           p + '/' + f
         end
+      end
+
+      def try_ext(f)
+        f if File.exist?(f)
       end
     end
   end

--- a/test/load_path_cache/cache_test.rb
+++ b/test/load_path_cache/cache_test.rb
@@ -51,6 +51,16 @@ module Bootsnap
         assert_equal("#{@dir2}/b.rb", cache.find('b'))
       end
 
+      def test_extension_append_for_relative_paths
+        po = [@dir1]
+        cache = Cache.new(NullCache, po)
+        Dir.chdir(@dir1) do
+          assert_equal("#{@dir1}/a.rb",       cache.find('./a'))
+          assert_equal("#{@dir1}/dl#{DLEXT}", cache.find('./dl'))
+          assert_equal("#{@dir1}/enoent",     cache.find('./enoent'))
+        end
+      end
+
       def test_unshifted_paths_have_higher_precedence
         po = [@dir1]
         cache = Cache.new(NullCache, po)


### PR DESCRIPTION
Without this change, this code:

    autoload(:B, './b')

Resolves to a path:

    $PWD/b # for example, /Users/me/src/foo/bar/app/lib/b

This is missing the .rb extension, which is normally fine because ruby
is happy to resolve it when we pass it to require, etc., but we also
insert that resolved path into our LoadedFeaturesIndex. Later, if we
attempt to purge that file from the LFI, we will generally have the full
path available, and therefore remove a non-existent entry, leaving the
not-fully-expanded one.

cc @Edouard-chin @byroot 