### PR TITLE
Don't mask LoadErrors:

### DIFF
--- a/lib/bootsnap/load_path_cache.rb
+++ b/lib/bootsnap/load_path_cache.rb
@@ -7,6 +7,11 @@ module Bootsnap
     DOT_SO = '.so'
     SLASH  = '/'
 
+    # If a NameError happens several levels deep, don't re-handle it
+    # all the way up the chain: mark it once and bubble it up without
+    # more retries.
+    ERROR_TAG_IVAR = :@__bootsnap_rescued
+
     DL_EXTENSIONS = ::RbConfig::CONFIG
       .values_at('DLEXT', 'DLEXT2')
       .reject { |ext| !ext || ext.empty? }

--- a/lib/bootsnap/load_path_cache/core_ext/active_support.rb
+++ b/lib/bootsnap/load_path_cache/core_ext/active_support.rb
@@ -18,11 +18,6 @@ module Bootsnap
           Thread.current[:without_bootsnap_retry] = prev
         end
 
-        # If a NameError happens several levels deep, don't re-handle it
-        # all the way up the chain: mark it once and bubble it up without
-        # more retries.
-        ERROR_TAG_IVAR = :@__bootsnap_rescued
-
         module ClassMethods
           def autoload_paths=(o)
             super
@@ -65,8 +60,8 @@ module Bootsnap
               super
             end
           rescue NameError => e
-            raise(e) if e.instance_variable_defined?(ERROR_TAG_IVAR)
-            e.instance_variable_set(ERROR_TAG_IVAR, true)
+            raise(e) if e.instance_variable_defined?(Bootsnap::LoadPathCache::ERROR_TAG_IVAR)
+            e.instance_variable_set(Bootsnap::LoadPathCache::ERROR_TAG_IVAR, true)
 
             # This function can end up called recursively, we only want to
             # retry at the top-level.
@@ -89,8 +84,8 @@ module Bootsnap
           def depend_on(*)
             super
           rescue LoadError => e
-            raise(e) if e.instance_variable_defined?(ERROR_TAG_IVAR)
-            e.instance_variable_set(ERROR_TAG_IVAR, true)
+            raise(e) if e.instance_variable_defined?(Bootsnap::LoadPathCache::ERROR_TAG_IVAR)
+            e.instance_variable_set(Bootsnap::LoadPathCache::ERROR_TAG_IVAR, true)
 
             # If we already had cache disabled, there's no use retrying
             raise(e) if Thread.current[:without_bootsnap_cache]

--- a/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb
+++ b/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb
@@ -3,6 +3,7 @@ module Bootsnap
     module CoreExt
       def self.make_load_error(path)
         err = LoadError.new("cannot load such file -- #{path}")
+        err.instance_variable_set(Bootsnap::LoadPathCache::ERROR_TAG_IVAR, true)
         err.define_singleton_method(:path) { path }
         err
       end
@@ -30,6 +31,9 @@ module Kernel
     end
 
     raise(Bootsnap::LoadPathCache::CoreExt.make_load_error(path))
+  rescue LoadError => e
+    e.instance_variable_set(Bootsnap::LoadPathCache::ERROR_TAG_IVAR, true)
+    raise(e)
   rescue Bootsnap::LoadPathCache::ReturnFalse
     false
   rescue Bootsnap::LoadPathCache::FallbackScan
@@ -56,6 +60,9 @@ module Kernel
     end
 
     raise(Bootsnap::LoadPathCache::CoreExt.make_load_error(path))
+  rescue LoadError => e
+    e.instance_variable_set(Bootsnap::LoadPathCache::ERROR_TAG_IVAR, true)
+    raise(e)
   rescue Bootsnap::LoadPathCache::ReturnFalse
     false
   rescue Bootsnap::LoadPathCache::FallbackScan
@@ -74,6 +81,9 @@ class Module
     # added to $LOADED_FEATURES and won't be able to hook that modification
     # since it's done in C-land.
     autoload_without_bootsnap(const, Bootsnap::LoadPathCache.load_path_cache.find(path) || path)
+  rescue LoadError => e
+    e.instance_variable_set(Bootsnap::LoadPathCache::ERROR_TAG_IVAR, true)
+    raise(e)
   rescue Bootsnap::LoadPathCache::ReturnFalse
     false
   rescue Bootsnap::LoadPathCache::FallbackScan


### PR DESCRIPTION
If a LoadError is generated by `require` while called with `load_dependency` further up the stack in some situations, the actual error would be masked by an irrelevant error.

This correctly propagates the initial error all the way back up the stack.

Fixes https://github.com/Shopify/bootsnap/issues/218