### PR TITLE
Avoid some string allocations

### DIFF
--- a/lib/bootsnap/load_path_cache.rb
+++ b/lib/bootsnap/load_path_cache.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Bootsnap
   module LoadPathCache
     ReturnFalse = Class.new(StandardError)

--- a/lib/bootsnap/load_path_cache/cache.rb
+++ b/lib/bootsnap/load_path_cache/cache.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative('../explicit_require')
 
 module Bootsnap

--- a/lib/bootsnap/load_path_cache/loaded_features_index.rb
+++ b/lib/bootsnap/load_path_cache/loaded_features_index.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Bootsnap
   module LoadPathCache
     # LoadedFeaturesIndex partially mirrors an internal structure in ruby that

--- a/lib/bootsnap/load_path_cache/path_scanner.rb
+++ b/lib/bootsnap/load_path_cache/path_scanner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative('../explicit_require')
 
 module Bootsnap
@@ -11,7 +13,7 @@ module Bootsnap
       BUNDLE_PATH = if Bootsnap.bundler?
         (Bundler.bundle_path.cleanpath.to_s << LoadPathCache::SLASH).freeze
       else
-        ''.freeze
+        ''
       end
 
       def self.call(path)


### PR DESCRIPTION
I've been running some memory profiling, and it seems that bootsnap is causing quite a lot of avoidable string allocations.

Here a partially redacted profile:

```
107073  ""

 24968  /tmp/bundle/ruby/2.5.0/gems/bootsnap-1.4.2.rc2/lib/bootsnap/load_path_cache/loaded_features_index.rb:89
 ...
  9349  /tmp/bundle/ruby/2.5.0/gems/bootsnap-1.4.2.rc2/lib/bootsnap/load_path_cache/loaded_features_index.rb:112
  9121  /tmp/bundle/ruby/2.5.0/gems/bootsnap-1.4.2.rc2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22
 ...
  2550  /tmp/bundle/ruby/2.5.0/gems/bootsnap-1.4.2.rc2/lib/bootsnap/load_path_cache/loaded_features_index.rb:92
 ...
   542  /tmp/bundle/ruby/2.5.0/gems/bootsnap-1.4.2.rc2/lib/bootsnap/load_path_cache/cache.rb:68
   540  /tmp/bundle/ruby/2.5.0/gems/bootsnap-1.4.2.rc2/lib/bootsnap/load_path_cache/cache.rb:63
 ...
   472  /tmp/bundle/ruby/2.5.0/gems/bootsnap-1.4.2.rc2/lib/bootsnap/load_path_cache/path.rb:76
 ...
   200  /tmp/bundle/ruby/2.5.0/gems/bootsnap-1.4.2.rc2/lib/bootsnap/load_path_cache/path_scanner.rb:39
 ...
   111  /tmp/bundle/ruby/2.5.0/gems/bootsnap-1.4.2.rc2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:54
 ...
    86  /tmp/bundle/ruby/2.5.0/gems/bootsnap-1.4.2.rc2/lib/bootsnap/load_path_cache/cache.rb:59
 ...
     5  /tmp/bundle/ruby/2.5.0/gems/bootsnap-1.4.2.rc2/lib/bootsnap/load_path_cache.rb:71
```

So that's a grand total of `47 944` instances of `""`. Not all of them are avoidable, some of them for instance are caused by `File.extname("no-extension")`, but this amount for `1.83 MiB` of ram usage, and we should be able to save a good part of these.

```
>> require 'objspace'
=> true
>> ObjectSpace.memsize_of('')
=> 40
>> ObjectSpace.memsize_of('') * 47_944
=> 1917760
```

@csfrancis @burke @rafaelfranca @Edouard-chin 