### PR TITLE
Add a hook for $LOADED_FEATURES.reject!

### DIFF
--- a/lib/bootsnap/load_path_cache/core_ext/loaded_features.rb
+++ b/lib/bootsnap/load_path_cache/core_ext/loaded_features.rb
@@ -4,4 +4,14 @@ class << $LOADED_FEATURES
     Bootsnap::LoadPathCache.loaded_features_index.purge(key)
     delete_without_bootsnap(key)
   end
+
+  alias_method(:reject_without_bootsnap!, :reject!)
+  def reject!(&block)
+    backup = dup
+
+    # FIXME: if no block is passed we'd need to return a decorated iterator
+    reject_without_bootsnap!(&block)
+
+    Bootsnap::LoadPathCache.loaded_features_index.purge_multi(backup - self)
+  end
 end

--- a/lib/bootsnap/load_path_cache/loaded_features_index.rb
+++ b/lib/bootsnap/load_path_cache/loaded_features_index.rb
@@ -57,6 +57,13 @@ module Bootsnap
         end
       end
 
+      def purge_multi(features)
+        rejected_hashes = features.map(&:hash).to_set
+        @mutex.synchronize do
+          @lfi.reject! { |_, hash| rejected_hashes.include?(hash) }
+        end
+      end
+
       def key?(feature)
         @mutex.synchronize { @lfi.key?(feature) }
       end

--- a/test/load_path_cache/loaded_features_index_test.rb
+++ b/test/load_path_cache/loaded_features_index_test.rb
@@ -65,6 +65,20 @@ module Bootsnap
         refute(@index.key?('foo'))
       end
 
+      def test_purge_multi_loaded_feature
+        refute(@index.key?('bundler'))
+        refute(@index.key?('bundler.rb'))
+        refute(@index.key?('foo'))
+        @index.register('bundler', '/a/b/bundler.rb') {}
+        assert(@index.key?('bundler'))
+        assert(@index.key?('bundler.rb'))
+        refute(@index.key?('foo'))
+        @index.purge_multi(['/a/b/bundler.rb', '/a/b/does-not-exist.rb'])
+        refute(@index.key?('bundler'))
+        refute(@index.key?('bundler.rb'))
+        refute(@index.key?('foo'))
+      end
+
       def test_register_finds_correct_feature
         refute(@index.key?('bundler'))
         refute(@index.key?('bundler.rb'))


### PR DESCRIPTION
Ref: https://github.com/fxn/zeitwerk/pull/32

TL;DR; Zeitwerk is removing paths one by one using `$LOADED_FEATURES.delete`, but that's terribly slow (`O(n*m)` more or less).

We'd like to use `$LOADED_FEATURES.reject!` instead to improve performance (over 30 times faster for Shopify core, but the bigger the `$LOADED_FEATURES` is, the slower it will be, so it might not be as noticeable on smaller apps).

From my initial test this is somewhat performant enough. My test scenario is unloading `172` paths out of `7585`, and it takes about 200ms (1s with Zeitwerk + Bootsnap).

I suppose this could be optimized further as the comments suggest, but I believe this PR is enough to change Zeitwerk reloading from "too slow to even be usable" to "could be better".

cc @fxn 