### PR TITLE
Cache permissions and umask issues after switch to mkstemp

### DIFF
--- a/ext/bootsnap/bootsnap.c
+++ b/ext/bootsnap/bootsnap.c
@@ -518,6 +518,10 @@ atomic_write_cache_file(char * path, struct bs_cache_key * key, VALUE data, char
   if (ret < 0) {
     *errno_provenance = (char *)"bs_fetch:atomic_write_cache_file:rename";
   }
+  ret = chmod(path, 0664);
+  if (ret < 0) {
+    *errno_provenance = (char *)"bs_fetch:atomic_write_cache_file:chmod";
+  }
   return ret;
 }
 

--- a/ext/bootsnap/bootsnap.c
+++ b/ext/bootsnap/bootsnap.c
@@ -521,6 +521,7 @@ atomic_write_cache_file(char * path, struct bs_cache_key * key, VALUE data, char
   ret = rename(tmp_path, path);
   if (ret < 0) {
     *errno_provenance = (char *)"bs_fetch:atomic_write_cache_file:rename";
+    return -1;
   }
   ret = chmod(path, 0664 & ~current_umask);
   if (ret < 0) {

--- a/ext/bootsnap/bootsnap.c
+++ b/ext/bootsnap/bootsnap.c
@@ -487,7 +487,6 @@ atomic_write_cache_file(char * path, struct bs_cache_key * key, VALUE data, char
       *errno_provenance = (char *)"bs_fetch:atomic_write_cache_file:mkpath";
       return -1;
     }
-    close(fd);
     fd = open(tmp_path, O_WRONLY | O_CREAT, 0664);
     if (fd < 0) {
       *errno_provenance = (char *)"bs_fetch:atomic_write_cache_file:open";


### PR DESCRIPTION
This PR resolves multiple permissions-related issues introduced in https://github.com/Shopify/bootsnap/pull/240. 

## State before the change

* When directory does not exist, it is being created with `mkpath` (respects `umask`, default permissions `0775`), and then file opened with `open` (respects `umask`, default permissions are `0664`).
* When the second file is created in the same directory, it uses `mkstemp`, which always creates files with permissions `0600`. **This causes various issues when permissions system relies on user groups, as the group can no longer read or write cache files.**

## After this change

* After directory first created, we use `open` to create first file.
* The second file is created with `mkstemp` call, which sets permissions to `0600`.
* To fix permissions, we apply `0644` to the file after rename, and properly use umask value (current `umask` is determined in the `Init_bootsnap`)

I have tested this change with and without umask, and it seems to be working properly:

* By default directories are created with `0775`
* Files are created with `0664`
* When umask `022` is specified, directories are `0755` and files are `0644`

## Previous behavior that was reverted by `mkstemp`

* https://github.com/Shopify/bootsnap/commit/be4e8476954f7c70b78a7bcf2e1fa45aa7008e77

### Related issues

* https://github.com/Shopify/bootsnap/issues/254 Unable to load application: Bootsnap::CompileCache::PermissionError
* https://github.com/Shopify/bootsnap/issues/171 Atomic write cache file error

### Updates

I was wrong about the second `open` call, it makes sense now and PR is corrected. ;-) The pemissions issue is still there.