### PR TITLE
Disable iseq cache in Ruby 2.5

### DIFF
--- a/lib/bootsnap/setup.rb
+++ b/lib/bootsnap/setup.rb
@@ -24,12 +24,15 @@ unless cache_dir
   cache_dir = File.join(app_root, 'tmp', 'cache')
 end
 
+ruby_version = Gem::Version.new(RUBY_VERSION)
+iseq_cache_enabled = ruby_version < Gem::Version.new('2.5.0') || ruby_version >= Gem::Version.new('2.6.0')
+
 Bootsnap.setup(
   cache_dir:            cache_dir,
   development_mode:     development_mode,
   load_path_cache:      true,
   autoload_paths_cache: true, # assume rails. open to PRs to impl. detection
   disable_trace:        false,
-  compile_cache_iseq:   true,
+  compile_cache_iseq:   iseq_cache_enabled,
   compile_cache_yaml:   true,
 )


### PR DESCRIPTION
There are many bugs in Ruby 2.5 related with iseq cache making it hard to use tracepoints with it. This means that debuggers and any gem that uses tracepoint don't play well with bootsnap when used with Ruby 2.5.

Until those issues are fixed in Ruby 2.5 we are going to disabled iseq cache in the `bootsnap/setup` file.

Fixes https://github.com/rails/rails/issues/35475.