### PR TITLE
Add helper_test with validating the cache path

### DIFF
--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -1,0 +1,12 @@
+require('test_helper')
+
+class HelperTest < MiniTest::Test
+  include(TmpdirHelper)
+
+  def test_validate_cache_path
+    path = Help.set_file('a.rb', 'a = a = 3', 100)
+    cp = Help.cache_path(@tmp_dir, path)
+    load(path)
+    assert_equal(true, File.file?(cp))
+  end
+end


### PR DESCRIPTION
This patch will add a test to validate the cache path, by comparing the actual cache path with the path generated by `Help.cache_path()` in `test_helper.rb`.

This patch assumes the `Help.cache_path()` equal with the path generated by C extension.