### PR TITLE
Add support for CRuby 2.7 or later

### DIFF
--- a/test/compile_cache_key_format_test.rb
+++ b/test/compile_cache_key_format_test.rb
@@ -35,7 +35,11 @@ class CompileCacheKeyFormatTest < Minitest::Test
 
   def test_key_ruby_revision
     key = cache_key_for_file(__FILE__)
-    exp = [RUBY_REVISION].pack("L")
+    if RUBY_REVISION.is_a?(String)
+      exp = [Help.fnv1a_64(RUBY_REVISION) >> 32].pack("L")
+    else
+      exp = [RUBY_REVISION].pack("L")
+    end
     assert_equal(exp, key[R[:ruby_revision]])
   end
 


### PR DESCRIPTION
CRuby 2.7 or later use Git commit ID as revision. It's String.