### PR TITLE
Don't break when Pathname is passed to LoadedFeaturesIndex

### DIFF
--- a/lib/bootsnap/load_path_cache/loaded_features_index.rb
+++ b/lib/bootsnap/load_path_cache/loaded_features_index.rb
@@ -133,7 +133,7 @@ module Bootsnap
       #
       # See <https://ruby-doc.org/core-2.6.4/Kernel.html#method-i-require>.
       def extension_elidable?(f)
-        f.end_with?('.rb', '.so', '.o', '.dll', '.dylib')
+        f.to_s.end_with?('.rb', '.so', '.o', '.dll', '.dylib')
       end
 
       def strip_extension_if_elidable(f)

--- a/test/load_path_cache/loaded_features_index_test.rb
+++ b/test/load_path_cache/loaded_features_index_test.rb
@@ -134,6 +134,13 @@ module Bootsnap
         assert(index.key?('minitest/autorun.rb'))
         refute(index.key?('minitest/autorun.so'))
       end
+
+      def test_works_with_pathname
+        path = '/tmp/bundler.rb'
+        pathname = Pathname.new(path)
+        @index.register(pathname, path) { true }
+        assert(@index.key?(pathname))
+      end
     end
   end
 end


### PR DESCRIPTION
After merging #271 I keep getting an error `undefined method 'end_with?' for #<Pathname:0x00007fe1222232f0>`

Full(er) trace:

```
An error occurred while loading ./spec/models/some_model_spec.rb.
Failure/Error: require File.expand_path('../../config/environment', __FILE__)

NoMethodError:
  undefined method `end_with?' for #<Pathname:0x00007fe1222232f0>
# /Users/pawel.swiatkowski/gems/bootsnap/lib/bootsnap/load_path_cache/loaded_features_index.rb:136:in `is_extension_elidable'
# /Users/pawel.swiatkowski/gems/bootsnap/lib/bootsnap/load_path_cache/loaded_features_index.rb:99:in `register'
# /Users/pawel.swiatkowski/gems/bootsnap/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:21:in `require_with_bootsnap_lfi'
# /Users/pawel.swiatkowski/gems/bootsnap/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
# ./config/initializers/solidus_paypal_braintree.rb:2:in `<main>'
# /Users/pawel.swiatkowski/gems/bootsnap/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:54:in `load'
# /Users/pawel.swiatkowski/gems/bootsnap/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:54:in `load'
# ./config/environment.rb:11:in `<top (required)>'
# ./spec/rails_helper.rb:4:in `require'
# ./spec/rails_helper.rb:4:in `<top (required)>'
# ./spec/models/some_model_spec.rb:1:in `require'
# ./spec/models/some_model_spec.rb:1:in `<top (required)>'
``` 

I'm not sure how `Pathname` got there in the first place, but the reality is that it did and now it stopped working. Adding `to_s` in `is_extension_elidable` is sufficient to make it work again. However perhaps pathnames should be converted to string somewhere earlier in the chain. I'm not sure...