### PR TITLE
Speed up LoadPathCache with more C

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ rvm:
   - ruby-2.4
   - ruby-2.5
   - ruby-head
+env:
+  - ENABLE_EXPERIMENTAL=1
+  - ''
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ rvm:
   - ruby-2.5
   - ruby-head
 env:
-  - ENABLE_EXPERIMENTAL=1
+  - BOOTSNAP_EXPERIMENTAL=1
   - ''
 
 matrix:

--- a/Rakefile
+++ b/Rakefile
@@ -9,5 +9,11 @@ Rake::ExtensionTask.new do |ext|
   ext.lib_dir = 'lib/bootsnap'
   ext.gem_spec = gemspec
 end
+Rake::ExtensionTask.new do |ext|
+  ext.name = 'dirscanner'
+  ext.ext_dir = 'ext/dirscanner'
+  ext.lib_dir = 'lib/bootsnap'
+  ext.gem_spec = gemspec
+end
 
 task(default: :compile)

--- a/bootsnap.gemspec
+++ b/bootsnap.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
     spec.platform = 'java'
   else
     spec.platform    = Gem::Platform::RUBY
-    spec.extensions  = ['ext/bootsnap/extconf.rb']
+    spec.extensions  = ['ext/bootsnap/extconf.rb', 'ext/dirscanner/extconf.rb']
   end
 
   spec.add_development_dependency("bundler")

--- a/ext/dirscanner/dirscanner.c
+++ b/ext/dirscanner/dirscanner.c
@@ -1,0 +1,106 @@
+#include "ruby.h"
+#include <dirent.h>
+#include <stdlib.h>
+
+static VALUE bs_dirscanner_scan(VALUE, VALUE, VALUE);
+void bs_dirscanner_scan_recursively(char*, char**, int);
+int bs_dirscanner_is_prefix(const char *pre, const char *str);
+
+static VALUE module, bootsnap_module;
+
+void
+Init_dirscanner(void)
+{
+  //bootsnap_module = rb_const_get(rb_cModule, rb_intern("Bootsnap"));
+  bootsnap_module = rb_define_module("Bootsnap");
+  module = rb_define_module_under(bootsnap_module, "DirScanner");
+  rb_define_module_function(module, "scan", bs_dirscanner_scan, 2);
+}
+
+static VALUE
+bs_dirscanner_scan(VALUE self, VALUE path, VALUE opts)
+{
+  char* c_path;
+  VALUE excluded, result;
+  char **exclusions;
+  int num_of_excluded, str_len, i;
+
+  excluded = rb_funcall(opts, rb_intern("[]"), 1, ID2SYM(rb_intern("excluded")));
+  if(NIL_P(excluded))
+  {
+    excluded = rb_ary_new();
+  }
+
+  c_path = RSTRING_PTR(path);
+
+  num_of_excluded = NUM2INT(rb_funcall(excluded, rb_intern("length"), 0));
+  exclusions = malloc(num_of_excluded * sizeof(char*));
+  for(i=0;i<num_of_excluded;i++)
+  {
+    result = rb_ary_entry(excluded, i);
+    Check_Type(result, T_STRING);
+    str_len = RSTRING_LEN(result);
+    exclusions[i] = RSTRING_PTR(result);
+  }
+
+  bs_dirscanner_scan_recursively(c_path, exclusions, num_of_excluded);
+
+  free(exclusions);
+
+  return Qnil;
+}
+
+// assuming that base_path is an absolute path
+void bs_dirscanner_scan_recursively(char *base_path, char **exclusions, int num_of_exclusions)
+{
+    char *path, *abspath, *formatted_str;
+    struct dirent *dp;
+    DIR *dir = opendir(base_path);
+    VALUE to_yield;
+    int i, should_skip = 0;
+
+    if (!dir)
+        return;
+
+    while ((dp = readdir(dir)) != NULL)
+    {
+      should_skip = 0;
+      if (strcmp(dp->d_name, ".") == 0 || strcmp(dp->d_name, "..") == 0)
+        continue;
+      
+      if(dp->d_name[0] == '.')
+        continue;
+
+      formatted_str = malloc(strlen(base_path) + strlen(dp->d_name) + 2);
+      sprintf(formatted_str, "%s/%s", base_path, dp->d_name);
+
+      for(i=0; i<num_of_exclusions; i++)
+      {
+        if(bs_dirscanner_is_prefix(exclusions[i], formatted_str))
+        {
+          should_skip = 1;
+        }
+      }
+      if(should_skip > 0) continue;
+
+      to_yield = rb_str_new_cstr(formatted_str);
+      rb_yield_values(1, to_yield);
+
+      // prepare for recursion
+      path = malloc(strlen(base_path) + 2 + strlen(dp->d_name) * sizeof(char));
+      strcpy(path, base_path);
+      strcat(path, "/");
+      strcat(path, dp->d_name);
+
+      bs_dirscanner_scan_recursively(path, exclusions, num_of_exclusions);
+
+      free(path);
+      free(formatted_str);
+    }
+    closedir(dir);
+}
+
+int bs_driscanner_is_prefix(const char *pre, const char *str)
+{
+    return strncmp(pre, str, strlen(pre)) == 0;
+}

--- a/ext/dirscanner/dirscanner.c
+++ b/ext/dirscanner/dirscanner.c
@@ -100,7 +100,7 @@ void bs_dirscanner_scan_recursively(char *base_path, char **exclusions, int num_
     closedir(dir);
 }
 
-int bs_driscanner_is_prefix(const char *pre, const char *str)
+int bs_dirscanner_is_prefix(const char *pre, const char *str)
 {
     return strncmp(pre, str, strlen(pre)) == 0;
 }

--- a/ext/dirscanner/extconf.rb
+++ b/ext/dirscanner/extconf.rb
@@ -1,0 +1,18 @@
+require("mkmf")
+$CFLAGS << ' -O3 '
+$CFLAGS << ' -std=c99'
+
+# ruby.h has some -Wpedantic fails in some cases
+# (e.g. https://github.com/Shopify/bootsnap/issues/15)
+unless ['0', '', nil].include?(ENV['BOOTSNAP_PEDANTIC'])
+  $CFLAGS << ' -Wall'
+  $CFLAGS << ' -Werror'
+  $CFLAGS << ' -Wextra'
+  $CFLAGS << ' -Wpedantic'
+
+  $CFLAGS << ' -Wno-unused-parameter' # VALUE self has to be there but we don't care what it is.
+  $CFLAGS << ' -Wno-keyword-macro' # hiding return
+  $CFLAGS << ' -Wno-gcc-compat' # ruby.h 2.6.0 on macos 10.14, dunno
+end
+
+create_makefile("bootsnap/dirscanner")

--- a/lib/bootsnap.rb
+++ b/lib/bootsnap.rb
@@ -14,7 +14,8 @@ module Bootsnap
     autoload_paths_cache: true,
     disable_trace: false,
     compile_cache_iseq: true,
-    compile_cache_yaml: true
+    compile_cache_yaml: true,
+    exclude_dirs: nil
   )
     if autoload_paths_cache && !load_path_cache
       raise(InvalidConfiguration, "feature 'autoload_paths_cache' depends on feature 'load_path_cache'")
@@ -25,7 +26,8 @@ module Bootsnap
     Bootsnap::LoadPathCache.setup(
       cache_path:       cache_dir + '/bootsnap-load-path-cache',
       development_mode: development_mode,
-      active_support:   autoload_paths_cache
+      active_support:   autoload_paths_cache,
+      exclude_dirs:     exclude_dirs
     ) if load_path_cache
 
     Bootsnap::CompileCache.setup(

--- a/lib/bootsnap.rb
+++ b/lib/bootsnap.rb
@@ -15,8 +15,9 @@ module Bootsnap
     disable_trace: false,
     compile_cache_iseq: true,
     compile_cache_yaml: true,
-    exclude_dirs: nil
+    exclude_paths: nil
   )
+
     if autoload_paths_cache && !load_path_cache
       raise(InvalidConfiguration, "feature 'autoload_paths_cache' depends on feature 'load_path_cache'")
     end
@@ -27,7 +28,7 @@ module Bootsnap
       cache_path:       cache_dir + '/bootsnap-load-path-cache',
       development_mode: development_mode,
       active_support:   autoload_paths_cache,
-      exclude_dirs:     exclude_dirs
+      exclude_paths:    exclude_paths
     ) if load_path_cache
 
     Bootsnap::CompileCache.setup(

--- a/lib/bootsnap/load_path_cache.rb
+++ b/lib/bootsnap/load_path_cache.rb
@@ -29,14 +29,15 @@ module Bootsnap
 
     class << self
       attr_reader(:load_path_cache, :autoload_paths_cache,
-        :loaded_features_index, :realpath_cache)
+        :loaded_features_index, :realpath_cache, :exclude_dirs)
 
-      def setup(cache_path:, development_mode:, active_support: true)
+      def setup(cache_path:, development_mode:, active_support: true, exclude_dirs: nil)
         unless supported?
           warn("[bootsnap/setup] Load path caching is not supported on this implementation of Ruby") if $VERBOSE
           return
         end
 
+        @exclude_dirs = exclude_dirs
         store = Store.new(cache_path)
 
         @loaded_features_index = LoadedFeaturesIndex.new

--- a/lib/bootsnap/load_path_cache.rb
+++ b/lib/bootsnap/load_path_cache.rb
@@ -29,15 +29,15 @@ module Bootsnap
 
     class << self
       attr_reader(:load_path_cache, :autoload_paths_cache,
-        :loaded_features_index, :realpath_cache, :exclude_dirs)
+        :loaded_features_index, :realpath_cache, :exclude_paths)
 
-      def setup(cache_path:, development_mode:, active_support: true, exclude_dirs: nil)
+      def setup(cache_path:, development_mode:, active_support: true, exclude_paths: nil)
         unless supported?
           warn("[bootsnap/setup] Load path caching is not supported on this implementation of Ruby") if $VERBOSE
           return
         end
 
-        @exclude_dirs = exclude_dirs
+        @exclude_paths = exclude_paths
         store = Store.new(cache_path)
 
         @loaded_features_index = LoadedFeaturesIndex.new

--- a/lib/bootsnap/load_path_cache/path_scanner.rb
+++ b/lib/bootsnap/load_path_cache/path_scanner.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative('../explicit_require')
+require 'bootsnap/dirscanner'
 
 module Bootsnap
   module LoadPathCache
@@ -16,7 +17,7 @@ module Bootsnap
         ''
       end
 
-      def self.call(path, excluded_paths: Bootsnap::LoadPathCache.exclude_dirs)
+      def self.call(path, excluded_paths: Bootsnap::LoadPathCache.exclude_paths)
         path = path.to_s
 
         relative_slice = (path.size + 1)..-1
@@ -45,8 +46,7 @@ module Bootsnap
 
         excluded = excluded_paths || []
 
-        if ENV['ENABLE_EXPERIMENTAL']
-          require 'bootsnap/dirscanner'
+        if ENV['BOOTSNAP_EXPERIMENTAL']
           DirScanner.scan(path, excluded: excluded) do |path|
             process_path.(path)
           end

--- a/test/dir_scanner_test.rb
+++ b/test/dir_scanner_test.rb
@@ -1,0 +1,74 @@
+require 'test_helper'
+require 'bootsnap/dirscanner'
+
+class DirScannerTest < Minitest::Test
+  DIRECTORIES = %w[node_modules tmp/cache tmp/important app lib].freeze
+  FILES = %w[
+    test test.rb tmp/cache/file.rb tmp/cache/.gitignore tmp/cache/test
+    tmp/important/file.rb tmp/file.rb node_modules/leftpad.js node_modules/right_pad
+    lib/file.rb lib/.gitignore app/config.rb tmp.rb
+  ].freeze
+
+  def with_directory_struture
+    Dir.mktmpdir do |dir|
+      DIRECTORIES.each do |dr|
+        FileUtils.mkdir_p(File.join(dir, dr))
+      end
+      FILES.each do |file|
+        FileUtils.touch(File.join(dir, file))
+      end
+
+      yield(dir)
+    end
+  end
+
+  def test_with_no_exclusions
+    with_directory_struture do |dir|
+      detected = []
+      Bootsnap::DirScanner.scan(dir, excluded: []) do |path|
+        detected << path
+      end
+
+      expected = (DIRECTORIES + FILES + ['tmp'])
+        .reject { |f| File.basename(f)[0] == '.' }
+        .sort
+        .map { |f| File.join(dir, f) }
+      
+      assert_equal(detected.sort, expected)
+    end
+  end
+
+  def test_without_second_argument
+    with_directory_struture do |dir|
+      detected = []
+      Bootsnap::DirScanner.scan(dir) do |path|
+        detected << path
+      end
+
+      expected = (DIRECTORIES + FILES + ['tmp'])
+        .reject { |f| File.basename(f)[0] == '.' }
+        .sort
+        .map { |f| File.join(dir, f) }
+      
+      assert_equal(detected.sort, expected)
+    end
+  end
+
+  def test_with_exclusions
+    with_directory_struture do |dir|
+      excluded = %w[node_modules tmp/cache].map { |f| File.join(dir, f) }
+      detected = []
+      Bootsnap::DirScanner.scan(dir, excluded: excluded) do |path|
+        detected << path
+      end
+
+      expected = %w[
+        tmp tmp/file.rb tmp/important tmp/important/file.rb  tmp.rb
+        app app/config.rb lib lib/file.rb
+        test test.rb
+      ].sort.map { |f| File.join(dir, f) }
+
+      assert_equal(detected.sort, expected)
+    end
+  end
+end

--- a/test/load_path_cache/path_scanner_test.rb
+++ b/test/load_path_cache/path_scanner_test.rb
@@ -29,6 +29,34 @@ module Bootsnap
           assert_equal(["a", "b", "b/c", "h", "h/i", "l", "l/m"], dirs.sort)
         end
       end
+
+      def test_path_exclusion
+        Dir.mktmpdir do |dir|
+          excluded_paths = [
+            File.join(dir, 'node_modules'),
+            File.join(dir, 'tmp', 'cache'),
+            File.join(dir, 'excludeme.rb'),
+            File.join(dir, 'excludemetoo.rb')
+          ]
+
+          %w[ruby/tmp/cache tmp/in_temp tmp/cache node_modules].each do |directory|
+            FileUtils.mkdir_p(File.join(dir, directory))
+          end
+
+          FileUtils.touch("#{dir}/ruby/a")
+          FileUtils.touch("#{dir}/ruby/d.rb")
+          FileUtils.touch("#{dir}/bundle.rb")
+          FileUtils.touch("#{dir}/excludeme.rb")
+          FileUtils.touch("#{dir}/tmp/in_temp/tmp.rb")
+          FileUtils.touch("#{dir}/tmp/cache/tmp.rb")
+          FileUtils.touch("#{dir}/ruby/tmp/cache/tmp.rb")
+          FileUtils.touch("#{dir}/node_modules/d.rb")
+
+          entries, dirs = PathScanner.call(dir, excluded_paths: excluded_paths)
+          assert_equal(%w[bundle.rb ruby/d.rb ruby/tmp/cache/tmp.rb tmp/in_temp/tmp.rb], entries.sort)
+          assert_equal(%w[ruby ruby/tmp ruby/tmp/cache tmp tmp/in_temp], dirs.sort)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
I decided to keep up the momentum with #277 and create a tenative pull request with my proposed changes to load path cache.

This includes:
- Additional option to exclude some path to try them as potential load path to scan
- New module in C to replace `Dir.glob`. It is both faster and easier on memory - unlike `Dir.glob` creating a large array and then iterating it, it yields with every found path and does path exclusion on C level.
- Extending TravisCI matrix to test both with this new extension and without

I tested those changes against Discourse, but without significant speedup:

|                     | cold | warm |
|---------------------|------|------|
| no exclusions, Ruby | 3.49 | 3.19 |
| no exclusions, C    | 3.48 | 3.2  |
| exclusions, Ruby    | 3.62 | 3.13 |
| exclusions, C       | 3.48 | 3.15 |

However, with my internal project with **a lot** of javascript (webpacker etc.), caching etc. savings are significant:

|                     | cold |       | warm |       |
|---------------------|------|-------|------|-------|
| no exclusions, Ruby | 9.45 | 0%    | 8.5  | 0%    |
| no exclusions, C    | 9.02 | 4.5%  | 7.94 | 6.5%  |
| exclusions, Ruby    | 8.49 | 10.1% | 6.83 | 19.6% |
| exclusions, C       | 6.92 | 26.7% | 6.86 | 19.2% |

**Legend:**
- cold - with load path cache purged (`rm tmp/cache/bootsnap-load-path-cache`)
- warm - with load path cache present and no changes to the files

I'm not the best C programmer (or even mediocre one), so to use this new C extension one must set environment variable `BOOTSNAP_EXPERIMENTAL`. This way people with project in dire need to speed up can experimentally use this, while most of the people can safely use existing version.

Let me know what you think about this direction.