### PR TITLE
Update minimum ruby version and fix rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ AllCops:
   Exclude:
     - 'vendor/**/*'
     - 'tmp/**/*'
-  TargetRubyVersion: '2.2'
+  TargetRubyVersion: '2.3'
 
 # This doesn't take into account retrying from an exception
 Lint/HandleExceptions:

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in bootsnap.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require('rake/extensiontask')
 require('bundler/gem_tasks')
 

--- a/bin/console
+++ b/bin/console
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require("bundler/setup")
 require("bootsnap")

--- a/bootsnap.gemspec
+++ b/bootsnap.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require('bootsnap/version')
@@ -26,7 +27,7 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = %w(lib)
 
-  spec.required_ruby_version = '>= 2.0.0'
+  spec.required_ruby_version = '>= 2.3.0'
 
   if RUBY_PLATFORM =~ /java/
     spec.platform = 'java'

--- a/ext/bootsnap/extconf.rb
+++ b/ext/bootsnap/extconf.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require("mkmf")
 $CFLAGS << ' -O3 '
 $CFLAGS << ' -std=c99'

--- a/lib/bootsnap.rb
+++ b/lib/bootsnap.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative('bootsnap/version')
 require_relative('bootsnap/bundler')
 require_relative('bootsnap/load_path_cache')

--- a/lib/bootsnap/bundler.rb
+++ b/lib/bootsnap/bundler.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Bootsnap
   extend(self)
 

--- a/lib/bootsnap/compile_cache.rb
+++ b/lib/bootsnap/compile_cache.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Bootsnap
   module CompileCache
     Error           = Class.new(StandardError)

--- a/lib/bootsnap/compile_cache/iseq.rb
+++ b/lib/bootsnap/compile_cache/iseq.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require('bootsnap/bootsnap')
 require('zlib')
 

--- a/lib/bootsnap/compile_cache/yaml.rb
+++ b/lib/bootsnap/compile_cache/yaml.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require('bootsnap/bootsnap')
 
 module Bootsnap

--- a/lib/bootsnap/explicit_require.rb
+++ b/lib/bootsnap/explicit_require.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Bootsnap
   module ExplicitRequire
     ARCHDIR    = RbConfig::CONFIG['archdir']

--- a/lib/bootsnap/load_path_cache/cache.rb
+++ b/lib/bootsnap/load_path_cache/cache.rb
@@ -67,7 +67,7 @@ module Bootsnap
           # native dynamic extension, e.g. .bundle or .so), we know it was a
           # failure and there's nothing more we can do to find the file.
           # no extension, .rb, (.bundle or .so)
-          when '', *CACHED_EXTENSIONS # rubocop:disable Performance/CaseWhenSplat
+          when '', *CACHED_EXTENSIONS
             nil
           # Ruby allows specifying native extensions as '.so' even when DLEXT
           # is '.bundle'. This is where we handle that case.
@@ -144,7 +144,7 @@ module Bootsnap
             expanded_path = p.expanded_path
             entries, dirs = p.entries_and_dirs(@store)
             # push -> low precedence -> set only if unset
-            dirs.each    { |dir| @dirs[dir]  ||= path }
+            dirs.each    { |dir| @dirs[dir] ||= path }
             entries.each { |rel| @index[rel] ||= expanded_path }
           end
         end

--- a/lib/bootsnap/load_path_cache/change_observer.rb
+++ b/lib/bootsnap/load_path_cache/change_observer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Bootsnap
   module LoadPathCache
     module ChangeObserver

--- a/lib/bootsnap/load_path_cache/core_ext/active_support.rb
+++ b/lib/bootsnap/load_path_cache/core_ext/active_support.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Bootsnap
   module LoadPathCache
     module CoreExt

--- a/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb
+++ b/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Bootsnap
   module LoadPathCache
     module CoreExt

--- a/lib/bootsnap/load_path_cache/core_ext/loaded_features.rb
+++ b/lib/bootsnap/load_path_cache/core_ext/loaded_features.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class << $LOADED_FEATURES
   alias_method(:delete_without_bootsnap, :delete)
   def delete(key)

--- a/lib/bootsnap/load_path_cache/loaded_features_index.rb
+++ b/lib/bootsnap/load_path_cache/loaded_features_index.rb
@@ -96,7 +96,7 @@ module Bootsnap
 
         # Do we have a filename with an elidable extension, e.g.,
         # 'bundler.rb', or 'libgit2.so'?
-        altname = if is_extension_elidable(short)
+        altname = if extension_elidable?(short)
           # Strip the extension off, e.g. 'bundler.rb' -> 'bundler'.
           strip_extension_if_elidable(short)
         elsif long && (ext = File.extname(long))
@@ -132,12 +132,12 @@ module Bootsnap
       # with callling a Ruby file 'x.dylib.rb' and then requiring it as 'x.dylib'.)
       #
       # See <https://ruby-doc.org/core-2.6.4/Kernel.html#method-i-require>.
-      def is_extension_elidable(f)
+      def extension_elidable?(f)
         f.end_with?('.rb', '.so', '.o', '.dll', '.dylib')
       end
 
       def strip_extension_if_elidable(f)
-        if is_extension_elidable(f)
+        if extension_elidable?(f)
           f.sub(STRIP_EXTENSION, '')
         else
           f

--- a/lib/bootsnap/load_path_cache/path.rb
+++ b/lib/bootsnap/load_path_cache/path.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative('path_scanner')
 
 module Bootsnap

--- a/lib/bootsnap/load_path_cache/store.rb
+++ b/lib/bootsnap/load_path_cache/store.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative('../explicit_require')
 
 Bootsnap::ExplicitRequire.with_gems('msgpack') { require('msgpack') }
@@ -63,11 +64,11 @@ module Bootsnap
       def load_data
         @data = begin
           MessagePack.load(File.binread(@store_path))
-          # handle malformed data due to upgrade incompatability
-        rescue Errno::ENOENT, MessagePack::MalformedFormatError, MessagePack::UnknownExtTypeError, EOFError
-          {}
-        rescue ArgumentError => e
-          e.message =~ /negative array size/ ? {} : raise
+                # handle malformed data due to upgrade incompatability
+                rescue Errno::ENOENT, MessagePack::MalformedFormatError, MessagePack::UnknownExtTypeError, EOFError
+                  {}
+                rescue ArgumentError => e
+                  e.message =~ /negative array size/ ? {} : raise
         end
       end
 

--- a/lib/bootsnap/setup.rb
+++ b/lib/bootsnap/setup.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative('../bootsnap')
 
 env = ENV['RAILS_ENV'] || ENV['RACK_ENV'] || ENV['ENV']

--- a/lib/bootsnap/version.rb
+++ b/lib/bootsnap/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Bootsnap
   VERSION = "1.4.5"
 end

--- a/test/bundler_test.rb
+++ b/test/bundler_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require('test_helper')
 
 class BundlerTest < Minitest::Test

--- a/test/compile_cache_handler_errors_test.rb
+++ b/test/compile_cache_handler_errors_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require('test_helper')
 
 class CompileCacheHandlerErrorsTest < Minitest::Test

--- a/test/compile_cache_key_format_test.rb
+++ b/test/compile_cache_key_format_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require('test_helper')
 require('tempfile')
 require('tmpdir')
@@ -35,10 +36,10 @@ class CompileCacheKeyFormatTest < Minitest::Test
 
   def test_key_ruby_revision
     key = cache_key_for_file(__FILE__)
-    if RUBY_REVISION.is_a?(String)
-      exp = [Help.fnv1a_64(RUBY_REVISION) >> 32].pack("L")
+    exp = if RUBY_REVISION.is_a?(String)
+      [Help.fnv1a_64(RUBY_REVISION) >> 32].pack("L")
     else
-      exp = [RUBY_REVISION].pack("L")
+      [RUBY_REVISION].pack("L")
     end
     assert_equal(exp, key[R[:ruby_revision]])
   end

--- a/test/compile_cache_test.rb
+++ b/test/compile_cache_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require('test_helper')
 
 class CompileCacheTest < Minitest::Test

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require('test_helper')
 
 class HelperTest < MiniTest::Test

--- a/test/load_path_cache/cache_test.rb
+++ b/test/load_path_cache/cache_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require('test_helper')
 
 module Bootsnap

--- a/test/load_path_cache/change_observer_test.rb
+++ b/test/load_path_cache/change_observer_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require('test_helper')
 
 module Bootsnap

--- a/test/load_path_cache/loaded_features_index_test.rb
+++ b/test/load_path_cache/loaded_features_index_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require('test_helper')
 
 module Bootsnap

--- a/test/load_path_cache/path_scanner_test.rb
+++ b/test/load_path_cache/path_scanner_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require('test_helper')
 
 module Bootsnap

--- a/test/load_path_cache/path_test.rb
+++ b/test/load_path_cache/path_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require('test_helper')
 require('bootsnap/load_path_cache')
 

--- a/test/load_path_cache/store_test.rb
+++ b/test/load_path_cache/store_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require('test_helper')
 require('tmpdir')
 require('fileutils')

--- a/test/minimal_support/bootsnap_setup.rb
+++ b/test/minimal_support/bootsnap_setup.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 require('bundler/setup')
 require('bootsnap/setup')

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 $LOAD_PATH.unshift(File.expand_path('../../lib', __FILE__))
 require('bundler/setup')
 require('bootsnap')


### PR DESCRIPTION
Fix https://github.com/Shopify/bootsnap/issues/279 by updating the minimum ruby version to 2.3 and fixing all rubocop offenses.