### PR TITLE
Update documentation on os_version -> ruby_platform

### DIFF
--- a/README.jp.md
+++ b/README.jp.md
@@ -152,7 +152,7 @@ close     n
 Bootsnap は、64バイトのヘッダーとそれに続くキャッシュの内容を含んだキャッシュファイルを書き込みます。ヘッダーは、次のいくつかのフィールドで構成されるキャッシュキーです。
 
 - `version`、Bootsnapにハードコードされる基本的なスキーマのバージョン
-- `os_version`、(macOS, BSDの) 現在のカーネルバージョンか 、(Linuxの) glibc のバージョンのハッシュ
+- `ruby_platform`、`RUBY_PLATFORM`（x86_64-linux-gnuなど）変数とOSバージョンのハッシュ（Linux、BSD、macOSでは` uname -v`）
 - `compile_option`、`RubyVM::InstructionSequence.compile_option` の返り値
 - `ruby_revision`、コンパイルされたRubyのバージョン
 - `size`、ソースファイルのサイズ

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Bootsnap writes a cache file containing a 64 byte header followed by the cache c
 is a cache key including several fields:
 
 * `version`, hardcoded in bootsnap. Essentially a schema version;
-* `os_version`, A hash of the current kernel version (on macOS, BSD) or glibc version (on Linux);
+* `ruby_platform`, A hash of `RUBY_PLATFORM` (e.g. x86_64-linux-gnu) variable and OS version (`uname -v` on Linux, BSD, macOS)
 * `compile_option`, which changes with `RubyVM::InstructionSequence.compile_option` does;
 * `ruby_revision`, the version of Ruby this was compiled with;
 * `size`, the size of the source file;

--- a/test/compile_cache_key_format_test.rb
+++ b/test/compile_cache_key_format_test.rb
@@ -9,7 +9,7 @@ class CompileCacheKeyFormatTest < Minitest::Test
 
   R = {
     version: 0...4,
-    os_version: 4...8,
+    ruby_platform: 4...8,
     compile_option: 8...12,
     ruby_revision: 12...16,
     size: 16...24,


### PR DESCRIPTION
The old documentation was ambiguous and incorrect. `uname -v` makes it
clear that the Bootsnap cache won't be reused in a Dockerized
application when the host kernel changes.