### PR TITLE
Add runtime dependency to thwait and e2mmap gems

### DIFF
--- a/bootsnap.gemspec
+++ b/bootsnap.gemspec
@@ -43,4 +43,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("mocha", "~> 1.2")
 
   spec.add_runtime_dependency("msgpack", "~> 1.0")
+  spec.add_runtime_dependency("thwait")
+  spec.add_runtime_dependency("e2mmap")
 end


### PR DESCRIPTION
These gem are no longer bundled to Ruby as of ruby-2.7.0
https://www.ruby-lang.org/en/news/2019/12/25/ruby-2-7-0-released/