### PR TITLE
Unfreeze string literal

### DIFF
--- a/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb
+++ b/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb
@@ -1,8 +1,9 @@
+# frozen_string_literal: true
 module Bootsnap
   module LoadPathCache
     module CoreExt
       def self.make_load_error(path)
-        err = LoadError.new("cannot load such file -- #{path}")
+        err = LoadError.new(+"cannot load such file -- #{path}")
         err.instance_variable_set(Bootsnap::LoadPathCache::ERROR_TAG_IVAR, true)
         err.define_singleton_method(:path) { path }
         err

--- a/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb
+++ b/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 module Bootsnap
   module LoadPathCache
     module CoreExt


### PR DESCRIPTION
Freezing the error message for LoadError triggers the
`can't modify frozen String` error at
https://github.com/rails/rails/blob/6-0-stable/activesupport/lib/active_support/dependencies.rb#L370
which `replace`s the error message