### PR TITLE
Add TruffleRuby back to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,7 @@ matrix:
     - rvm: jruby
       os: linux
       env: MINIMAL_SUPPORT=1
-
+    - rvm: truffleruby
+      os: linux
+      env: MINIMAL_SUPPORT=1
 script: bin/ci


### PR DESCRIPTION
It passes now! This commit is a revert of https://github.com/Shopify/bootsnap/commit/81dc814fc9967852d29d30150bb1eb940b8c75e2

cc @eregon 