### PR TITLE
HACK: try to store iseqs in LMDB to reduce the number of opened files

### DIFF
--- a/bootsnap.gemspec
+++ b/bootsnap.gemspec
@@ -43,4 +43,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("mocha", "~> 1.2")
 
   spec.add_runtime_dependency("msgpack", "~> 1.0")
+  spec.add_runtime_dependency("lmdb")
 end

--- a/lib/bootsnap/compile_cache/iseq.rb
+++ b/lib/bootsnap/compile_cache/iseq.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require('bootsnap/bootsnap')
+require_relative('lmdb')
 require('zlib')
 
 module Bootsnap
@@ -35,7 +36,7 @@ module Bootsnap
           # Having coverage enabled prevents iseq dumping/loading.
           return nil if defined?(Coverage) && Bootsnap::CompileCache::Native.coverage_running?
 
-          Bootsnap::CompileCache::Native.fetch(
+          Bootsnap::CompileCache::LMDB.fetch(
             Bootsnap::CompileCache::ISeq.cache_dir,
             path.to_s,
             Bootsnap::CompileCache::ISeq

--- a/lib/bootsnap/compile_cache/lmdb.rb
+++ b/lib/bootsnap/compile_cache/lmdb.rb
@@ -1,0 +1,38 @@
+require 'fileutils'
+require 'lmdb'
+
+module Bootsnap
+  module CompileCache
+    module LMDB
+      MAX_SIZE = 2 ** 30 # 1GiB
+
+      class << self
+        def fetch(cache_dir, path, handler)
+          ensure_database_exists!(cache_dir)
+
+          # TODO: check wether it's inside GEM_PATH
+          # We could consider gems as immutable and save this `mtime`.
+          source_mtime = File.mtime(path).to_i
+          cache_mtime = @database.get("mtime:#{path}").to_i
+
+          if cache_mtime >= source_mtime
+            handler.storage_to_output(@database.get(path))
+          else
+            content = handler.input_to_storage(nil, path)
+            @database.put(path, content)
+            @database.put("mtime:#{path}", source_mtime.to_s)
+            handler.storage_to_output(content)
+          end
+        end
+
+        def ensure_database_exists!(cache_dir)
+          return if defined? @database
+
+          FileUtils.mkdir_p(cache_dir)
+          @env = ::LMDB.new(File.join(cache_dir), mapsize: MAX_SIZE, nometasync: true, nosync: true)
+          @database = @env.database('bootsnap', create: true)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a huge hack to work as a proof of concept

For context: https://discuss.rubyonrails.org/t/why-is-rails-boot-so-slow-on-macos/74021

`open()` is 2.5 times slower on macOS than on a LinuxVM running on the same host. So this draft is trying an alternative LMDB store for the iseq caches, hoping to open less files, hence be a bit faster.