### PR TITLE
Update .rubocop.yml to fix the offence

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ AllCops:
   TargetRubyVersion: '2.3'
 
 # This doesn't take into account retrying from an exception
-Lint/HandleExceptions:
+Lint/SuppressedException:
   Enabled: false
 
 # allow String.new to create mutable strings

--- a/lib/bootsnap.rb
+++ b/lib/bootsnap.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative('bootsnap/version')
 require_relative('bootsnap/bundler')
 require_relative('bootsnap/load_path_cache')


### PR DESCRIPTION
Fix for the below error.
Error: The `Lint/HandleExceptions` cop has been renamed to `Lint/SuppressedException`
(obsolete configuration found in vendor/bundle/ruby/2.7.0/gems/bootsnap-1.4.6/.rubocop.yml, please update it)