### PR TITLE
Update CI to test Ruby 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,10 @@ os:
   - osx
 
 rvm:
-  - ruby-2.4
-  - ruby-2.5
+  - '2.4'
+  - '2.5'
+  - '2.6'
+  - '2.7'
   - ruby-head
 
 matrix:

--- a/Rakefile
+++ b/Rakefile
@@ -10,4 +10,8 @@ Rake::ExtensionTask.new do |ext|
   ext.gem_spec = gemspec
 end
 
-task(default: :compile)
+task :test do
+  sh 'bin/testunit'
+end
+
+task(default: %i(compile test))

--- a/bin/ci
+++ b/bin/ci
@@ -5,6 +5,5 @@ set -euxo pipefail
 if [[ "${MINIMAL_SUPPORT-0}" -eq 1 ]]; then
   exec bin/test-minimal-support
 else
-  rake
-  exec bin/testunit
+  exec rake
 fi

--- a/bootsnap.gemspec
+++ b/bootsnap.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_development_dependency("bundler")
-  spec.add_development_dependency('rake', '~> 10.0')
+  spec.add_development_dependency('rake')
   spec.add_development_dependency('rake-compiler', '~> 0')
   spec.add_development_dependency("minitest", "~> 5.0")
   spec.add_development_dependency("mocha", "~> 1.2")

--- a/ext/bootsnap/bootsnap.c
+++ b/ext/bootsnap/bootsnap.c
@@ -800,7 +800,7 @@ try_input_to_storage(VALUE arg)
 }
 
 static VALUE
-rescue_input_to_storage(VALUE arg)
+rescue_input_to_storage(VALUE arg, VALUE e)
 {
   return uncompilable;
 }


### PR DESCRIPTION
What the title says.

I had to update `rescue_input_to_storage`'s signature because it was issuing a compilation warning on 2.7+