### PR TITLE
Reduce allocations by freezing paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,10 @@ os:
   - osx
 
 rvm:
-  - ruby-2.4
-  - ruby-2.5
+  - '2.4'
+  - '2.5'
+  - '2.6'
+  - '2.7'
   - ruby-head
 
 matrix:

--- a/Rakefile
+++ b/Rakefile
@@ -10,4 +10,8 @@ Rake::ExtensionTask.new do |ext|
   ext.gem_spec = gemspec
 end
 
-task(default: :compile)
+task :test do
+  sh 'bin/testunit'
+end
+
+task(default: %i(compile test))

--- a/bin/ci
+++ b/bin/ci
@@ -5,6 +5,5 @@ set -euxo pipefail
 if [[ "${MINIMAL_SUPPORT-0}" -eq 1 ]]; then
   exec bin/test-minimal-support
 else
-  rake
-  exec bin/testunit
+  exec rake
 fi

--- a/bootsnap.gemspec
+++ b/bootsnap.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_development_dependency("bundler")
-  spec.add_development_dependency('rake', '~> 10.0')
+  spec.add_development_dependency('rake')
   spec.add_development_dependency('rake-compiler', '~> 0')
   spec.add_development_dependency("minitest", "~> 5.0")
   spec.add_development_dependency("mocha", "~> 1.2")

--- a/ext/bootsnap/bootsnap.c
+++ b/ext/bootsnap/bootsnap.c
@@ -800,7 +800,7 @@ try_input_to_storage(VALUE arg)
 }
 
 static VALUE
-rescue_input_to_storage(VALUE arg)
+rescue_input_to_storage(VALUE arg, VALUE e)
 {
   return uncompilable;
 }

--- a/lib/bootsnap/load_path_cache/cache.rb
+++ b/lib/bootsnap/load_path_cache/cache.rb
@@ -46,7 +46,7 @@ module Bootsnap
       # loadpath.
       def find(feature)
         reinitialize if (@has_relative_paths && dir_changed?) || stale?
-        feature = feature.to_s
+        feature = feature.to_s.freeze
         return feature if absolute_path?(feature)
         return expand_path(feature) if feature.start_with?('./')
         @mutex.synchronize do
@@ -178,25 +178,25 @@ module Bootsnap
 
       if DLEXT2
         def search_index(f)
-          try_index(f + DOT_RB) || try_index(f + DLEXT) || try_index(f + DLEXT2) || try_index(f)
+          try_index("#{f}#{DOT_RB}") || try_index("#{f}#{DLEXT}") || try_index("#{f}#{DLEXT2}") || try_index(f)
         end
 
         def maybe_append_extension(f)
-          try_ext(f + DOT_RB) || try_ext(f + DLEXT) || try_ext(f + DLEXT2) || f
+          try_ext("#{f}#{DOT_RB}") || try_ext("#{f}#{DLEXT}") || try_ext("#{f}#{DLEXT2}") || f
         end
       else
         def search_index(f)
-          try_index(f + DOT_RB) || try_index(f + DLEXT) || try_index(f)
+          try_index("#{f}#{DOT_RB}") || try_index("#{f}#{DLEXT}") || try_index(f)
         end
 
         def maybe_append_extension(f)
-          try_ext(f + DOT_RB) || try_ext(f + DLEXT) || f
+          try_ext("#{f}#{DOT_RB}") || try_ext("#{f}#{DLEXT}") || f
         end
       end
 
       def try_index(f)
         if (p = @index[f])
-          p + '/' + f
+          "#{p}/#{f}"
         end
       end
 

--- a/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb
+++ b/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb
@@ -56,7 +56,7 @@ module Kernel
     end
 
     # load also allows relative paths from pwd even when not in $:
-    if File.exist?(relative = File.expand_path(path))
+    if File.exist?(relative = File.expand_path(path).freeze)
       return load_without_bootsnap(relative, wrap)
     end
 

--- a/lib/bootsnap/load_path_cache/loaded_features_index.rb
+++ b/lib/bootsnap/load_path_cache/loaded_features_index.rb
@@ -99,7 +99,7 @@ module Bootsnap
         altname = if extension_elidable?(short)
           # Strip the extension off, e.g. 'bundler.rb' -> 'bundler'.
           strip_extension_if_elidable(short)
-        elsif long && (ext = File.extname(long))
+        elsif long && (ext = File.extname(long.freeze))
           # We already know the extension of the actual file this
           # resolves to, so put that back on.
           short + ext

--- a/lib/bootsnap/load_path_cache/path.rb
+++ b/lib/bootsnap/load_path_cache/path.rb
@@ -21,7 +21,7 @@ module Bootsnap
       attr_reader(:path)
 
       def initialize(path)
-        @path = path.to_s
+        @path = path.to_s.freeze
       end
 
       # True if the path exists, but represents a non-directory object
@@ -60,7 +60,7 @@ module Bootsnap
       end
 
       def expanded_path
-        File.expand_path(path)
+        File.expand_path(path).freeze
       end
 
       private

--- a/lib/bootsnap/load_path_cache/path_scanner.rb
+++ b/lib/bootsnap/load_path_cache/path_scanner.rb
@@ -33,8 +33,9 @@ module Bootsnap
         requirables = []
 
         Dir.glob(path + ALL_FILES).each do |absolute_path|
+          absolute_path.freeze
           next if contains_bundle_path && absolute_path.start_with?(BUNDLE_PATH)
-          relative_path = absolute_path.slice(relative_slice)
+          relative_path = absolute_path.slice(relative_slice).freeze
 
           if File.directory?(absolute_path)
             dirs << relative_path

--- a/lib/bootsnap/load_path_cache/realpath_cache.rb
+++ b/lib/bootsnap/load_path_cache/realpath_cache.rb
@@ -15,15 +15,15 @@ module Bootsnap
 
       def realpath(caller_location, path)
         base = File.dirname(caller_location)
-        file = find_file(File.expand_path(path, base))
-        dir = File.dirname(file)
-        File.join(dir, File.basename(file))
+        abspath = File.expand_path(path, base).freeze
+        find_file(abspath)
       end
 
       def find_file(name)
-        ['', *CACHED_EXTENSIONS].each do |ext|
+        return File.realpath(name).freeze if File.exist?(name)
+        CACHED_EXTENSIONS.each do |ext|
           filename = "#{name}#{ext}"
-          return File.realpath(filename) if File.exist?(filename)
+          return File.realpath(filename).freeze if File.exist?(filename)
         end
         name
       end


### PR DESCRIPTION
Base on https://github.com/Shopify/bootsnap/pull/310 for CI purposes.

This patch is based on an implementation detail of MRI. Pretty much all `File` methods call `FilePathStringValue()` on the passed path. This method will always dup the string unless it's already frozen. As a result freezing paths before calling `File methods will save one string allocation the vast majority of the time.

```ruby
s = __FILE__
alloc = GC.stat(:total_allocated_objects)
File.exist?(s)
p GC.stat(:total_allocated_objects) - alloc # => 1

s = __FILE__.freeze
alloc = GC.stat(:total_allocated_objects)
real = File.exist?(s)
p GC.stat(:total_allocated_objects) - alloc # => 0
```

Of course it only really matter it loops, but Bootsnap have a few of these. 