### PR TITLE
Refactor PathScanner to avoid Dir.glob

### DIFF
--- a/lib/bootsnap/load_path_cache/path_scanner.rb
+++ b/lib/bootsnap/load_path_cache/path_scanner.rb
@@ -5,7 +5,6 @@ require_relative('../explicit_require')
 module Bootsnap
   module LoadPathCache
     module PathScanner
-      ALL_FILES = "/{,**/*/**/}*"
       REQUIRABLE_EXTENSIONS = [DOT_RB] + DL_EXTENSIONS
       NORMALIZE_NATIVE_EXTENSIONS = !DL_EXTENSIONS.include?(LoadPathCache::DOT_SO)
       ALTERNATIVE_NATIVE_EXTENSIONS_PATTERN = /\.(o|bundle|dylib)\z/
@@ -16,35 +15,47 @@ module Bootsnap
         ''
       end
 
-      def self.call(path)
-        path = path.to_s
+      class << self
+        def call(path)
+          path = File.expand_path(path.to_s).freeze
 
-        relative_slice = (path.size + 1)..-1
-        # If the bundle path is a descendent of this path, we do additional
-        # checks to prevent recursing into the bundle path as we recurse
-        # through this path. We don't want to scan the bundle path because
-        # anything useful in it will be present on other load path items.
-        #
-        # This can happen if, for example, the user adds '.' to the load path,
-        # and the bundle path is '.bundle'.
-        contains_bundle_path = BUNDLE_PATH.start_with?(path)
+          # If the bundle path is a descendent of this path, we do additional
+          # checks to prevent recursing into the bundle path as we recurse
+          # through this path. We don't want to scan the bundle path because
+          # anything useful in it will be present on other load path items.
+          #
+          # This can happen if, for example, the user adds '.' to the load path,
+          # and the bundle path is '.bundle'.
+          contains_bundle_path = BUNDLE_PATH.start_with?(path)
 
-        dirs = []
-        requirables = []
-
-        Dir.glob(path + ALL_FILES).each do |absolute_path|
-          absolute_path.freeze
-          next if contains_bundle_path && absolute_path.start_with?(BUNDLE_PATH)
-          relative_path = absolute_path.slice(relative_slice).freeze
-
-          if File.directory?(absolute_path)
-            dirs << relative_path
-          elsif REQUIRABLE_EXTENSIONS.include?(File.extname(relative_path))
-            requirables << relative_path
+          dirs = []
+          requirables = []
+          walk(path, nil) do |relative_path, absolute_path, is_directory|
+            if is_directory
+              dirs << relative_path
+              !contains_bundle_path || !absolute_path.start_with?(BUNDLE_PATH)
+            elsif relative_path.end_with?(*REQUIRABLE_EXTENSIONS)
+              requirables << relative_path
+            end
           end
+          [requirables, dirs]
         end
 
-        [requirables, dirs]
+        def walk(absolute_dir_path, relative_dir_path, &block)
+          Dir.foreach(absolute_dir_path) do |name|
+            next if name.start_with?('.')
+            relative_path = relative_dir_path ? "#{relative_dir_path}/#{name}" : name.freeze
+
+            absolute_path = "#{absolute_dir_path}/#{name}"
+            if File.directory?(absolute_path)
+              if yield relative_path, absolute_path, true
+                walk(absolute_path, relative_path, &block)
+              end
+            else
+              yield relative_path, absolute_path, false
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
My main concern with `Dir.glob` is that it becomes sorted by default in `2.8/3.0` which makes it quite slower for large result sets. That can easily be fixed by passing `sort: false`, but while I was at it I figured there might be ways to avoid the cost of allocating and returning giant arrays.

So instead I use `foreach` which yield directory entries one by one.

I benched it against large directories and it's noticeably faster: https://gist.github.com/casperisfine/68819290350f8036d48a1d71777d5616

```
Calculating -------------------------------------
            original     18.595  (± 5.4%) i/s -    372.000  in  20.025736s
                 new     25.369  (± 3.9%) i/s -    508.000  in  20.037516s

Comparison:
                 new:       25.4 i/s
            original:       18.6 i/s - 1.36x  (± 0.00) slower
```
