### PR TITLE
Add fallback: parameter to YAML.load_file redefinition.

### DIFF
--- a/lib/bootsnap/compile_cache/yaml.rb
+++ b/lib/bootsnap/compile_cache/yaml.rb
@@ -46,13 +46,13 @@ module Bootsnap
         Bootsnap::CompileCache::YAML.msgpack_factory = factory
 
         klass = class << ::YAML; self; end
-        klass.send(:define_method, :load_file) do |path|
+        klass.send(:define_method, :load_file) do |path, fallback: false|
           begin
             Bootsnap::CompileCache::Native.fetch(
               cache_dir,
               path,
               Bootsnap::CompileCache::YAML
-            )
+            ) || fallback
           rescue Errno::EACCES
             Bootsnap::CompileCache.permission_error(path)
           end


### PR DESCRIPTION
Recent versions of the `YAML` module have added a named `fallback`
parameter to `YAML.load_file`. However, the redefinition in `yaml.rb`
does not account for that parameter; this patch fixes that. As per
`YAML`, the `fallback` value defaults to `false`.

I chose to make this modification on the Ruby level rather than
plumbing a `fallback` parameter through the native C
extensions, though I'm happy to do that should the need arise. The
`load_file` redefinition doesn't appear to be exercised in the tests;
I'm happy to fix this as well.

Fixes #303.