### PR TITLE
Prevent FallbackScan from polluting exception cause

### DIFF
--- a/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb
+++ b/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb
@@ -38,7 +38,11 @@ module Kernel
   rescue Bootsnap::LoadPathCache::ReturnFalse
     false
   rescue Bootsnap::LoadPathCache::FallbackScan
-    require_with_bootsnap_lfi(path)
+    fallback = true
+  ensure
+    if fallback
+      require_with_bootsnap_lfi(path)
+    end
   end
 
   alias_method(:require_relative_without_bootsnap, :require_relative)
@@ -67,7 +71,11 @@ module Kernel
   rescue Bootsnap::LoadPathCache::ReturnFalse
     false
   rescue Bootsnap::LoadPathCache::FallbackScan
-    load_without_bootsnap(path, wrap)
+    fallback = true
+  ensure
+    if fallback
+      load_without_bootsnap(path, wrap)
+    end
   end
 end
 
@@ -88,6 +96,10 @@ class Module
   rescue Bootsnap::LoadPathCache::ReturnFalse
     false
   rescue Bootsnap::LoadPathCache::FallbackScan
-    autoload_without_bootsnap(const, path)
+    fallback = true
+  ensure
+    if fallback
+      autoload_without_bootsnap(const, path)
+    end
   end
 end


### PR DESCRIPTION
When debugging an issue with [test-bench](https://github.com/test-bench/test-bench) and bootsnap, I discovered that bootsnap pollutes error.cause by requiring the file naturally after a fallback scan within a rescue. This causes any error that is thrown within the required file to have a `#cause` defined, which it should not. This improves output in test-bench when an error occurs and it may (I haven't tested this) improve output in other frameworks that inspect error.cause.

I wasn't sure how to write a test for this because I didn't know how to trigger a fallback scan (I don't even really know what that is) and still load a real file that raises an exception. If you could give me a snippet for that I can add a test.

Thanks!