### PR TITLE
Remove unnecessary files from bundled gem

### DIFF
--- a/bootsnap.gemspec
+++ b/bootsnap.gemspec
@@ -22,9 +22,7 @@ Gem::Specification.new do |spec|
     'source_code_uri' => 'https://github.com/Shopify/bootsnap',
   }
 
-  spec.files = %x(git ls-files -z).split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
-  end
+  spec.files = %x(git ls-files -z ext lib).split("\x0") + %w(CHANGELOG.md LICENSE.txt README.md)
   spec.require_paths = %w(lib)
 
   spec.required_ruby_version = '>= 2.3.0'


### PR DESCRIPTION
## Summary

This PR slims down the bundled gem by ~21%.

|                       | Compressed .gem size (bytes) | Unpacked size (bytes) |
|-----------------------|-----------------------------:|----------------------:|
| Before                |                       40,448 |               138,324 |
| After                 |                       31,744 |               108,004 |
| Difference (absolute) |                        8,704 |                30,320 |
| Difference (relative) |                      -21.52% |               -21.92% |

I believe these savings are worth having because this gem is downloaded millions of times.

## Changes

 - Omitted all files from the gem except for `ext/`, `lib/` and a few other common files.


<details>
<summary>Before (details)</summary>

```
## Compressed .gem size

40448 bytes

## Gem contents

-rw-r--r--  0 wheel  wheel      26 Aug  4 21:17 .github/CODEOWNERS
-rw-r--r--  0 wheel  wheel      17 Aug  4 21:17 .github/probots.yml
-rw-r--r--  0 wheel  wheel     140 Aug  4 21:17 .gitignore
-rw-r--r--  0 wheel  wheel     448 Aug  4 21:17 .rubocop.yml
-rw-r--r--  0 wheel  wheel     314 Aug  4 21:17 .travis.yml
-rw-r--r--  0 wheel  wheel    3588 Aug  4 21:17 CHANGELOG.md
-rw-r--r--  0 wheel  wheel    3223 Aug  4 21:17 CODE_OF_CONDUCT.md
-rw-r--r--  0 wheel  wheel     789 Aug  4 21:17 CONTRIBUTING.md
-rw-r--r--  0 wheel  wheel     166 Aug  4 21:17 Gemfile
-rw-r--r--  0 wheel  wheel    1080 Aug  4 21:17 LICENSE.txt
-rw-r--r--  0 wheel  wheel   13853 Aug  4 21:17 README.jp.md
-rw-r--r--  0 wheel  wheel   11719 Aug  4 21:17 README.md
-rw-r--r--  0 wheel  wheel     364 Aug  4 21:17 Rakefile
-rwxr-xr-x  0 wheel  wheel     129 Aug  4 21:17 bin/ci
-rwxr-xr-x  0 wheel  wheel     376 Aug  4 21:17 bin/console
-rwxr-xr-x  0 wheel  wheel     131 Aug  4 21:17 bin/setup
-rwxr-xr-x  0 wheel  wheel     139 Aug  4 21:17 bin/test-minimal-support
-rwxr-xr-x  0 wheel  wheel     208 Aug  4 21:17 bin/testunit
-rw-r--r--  0 wheel  wheel    1467 Aug  4 21:17 bootsnap.gemspec
-rw-r--r--  0 wheel  wheel     166 Aug  4 21:17 dev.yml
-rw-r--r--  0 wheel  wheel   25749 Aug  4 21:17 ext/bootsnap/bootsnap.c
-rw-r--r--  0 wheel  wheel      96 Aug  4 21:17 ext/bootsnap/bootsnap.h
-rw-r--r--  0 wheel  wheel     607 Aug  4 21:17 ext/bootsnap/extconf.rb
-rw-r--r--  0 wheel  wheel    1455 Aug  4 21:17 lib/bootsnap.rb
-rw-r--r--  0 wheel  wheel     282 Aug  4 21:17 lib/bootsnap/bundler.rb
-rw-r--r--  0 wheel  wheel    1354 Aug  4 21:17 lib/bootsnap/compile_cache.rb
-rw-r--r--  0 wheel  wheel    2096 Aug  4 21:17 lib/bootsnap/compile_cache/iseq.rb
-rw-r--r--  0 wheel  wheel    2031 Aug  4 21:17 lib/bootsnap/compile_cache/yaml.rb
-rw-r--r--  0 wheel  wheel    1484 Aug  4 21:17 lib/bootsnap/explicit_require.rb
-rw-r--r--  0 wheel  wheel    2682 Aug  4 21:17 lib/bootsnap/load_path_cache.rb
-rw-r--r--  0 wheel  wheel    6970 Aug  4 21:17 lib/bootsnap/load_path_cache/cache.rb
-rw-r--r--  0 wheel  wheel    2147 Aug  4 21:17 lib/bootsnap/load_path_cache/change_observer.rb
-rw-r--r--  0 wheel  wheel    4075 Aug  4 21:17 lib/bootsnap/load_path_cache/core_ext/active_support.rb
-rw-r--r--  0 wheel  wheel    3133 Aug  4 21:17 lib/bootsnap/load_path_cache/core_ext/kernel_require.rb
-rw-r--r--  0 wheel  wheel     518 Aug  4 21:17 lib/bootsnap/load_path_cache/core_ext/loaded_features.rb
-rw-r--r--  0 wheel  wheel    5460 Aug  4 21:17 lib/bootsnap/load_path_cache/loaded_features_index.rb
-rw-r--r--  0 wheel  wheel    3574 Aug  4 21:17 lib/bootsnap/load_path_cache/path.rb
-rw-r--r--  0 wheel  wheel    2231 Aug  4 21:17 lib/bootsnap/load_path_cache/path_scanner.rb
-rw-r--r--  0 wheel  wheel     721 Aug  4 21:17 lib/bootsnap/load_path_cache/realpath_cache.rb
-rw-r--r--  0 wheel  wheel    2620 Aug  4 21:17 lib/bootsnap/load_path_cache/store.rb
-rw-r--r--  0 wheel  wheel    1344 Aug  4 21:17 lib/bootsnap/setup.rb
-rw-r--r--  0 wheel  wheel      70 Aug  4 21:17 lib/bootsnap/version.rb
-rw-r--r--  0 wheel  wheel       0 Aug  4 21:17 shipit.rubygems.yml

## Unpacked size

138324 bytes
```

</details>

<details>
<summary>After (details)</summary>

```
## Compressed .gem size

31744 bytes

## Gem contents

-rw-r--r--  0 wheel  wheel    3588 Aug  4 21:17 CHANGELOG.md
-rw-r--r--  0 wheel  wheel    1080 Aug  4 21:17 LICENSE.txt
-rw-r--r--  0 wheel  wheel   11719 Aug  4 21:17 README.md
-rw-r--r--  0 wheel  wheel   25749 Aug  4 21:17 ext/bootsnap/bootsnap.c
-rw-r--r--  0 wheel  wheel      96 Aug  4 21:17 ext/bootsnap/bootsnap.h
-rw-r--r--  0 wheel  wheel     607 Aug  4 21:17 ext/bootsnap/extconf.rb
-rw-r--r--  0 wheel  wheel    1455 Aug  4 21:17 lib/bootsnap.rb
-rw-r--r--  0 wheel  wheel     282 Aug  4 21:17 lib/bootsnap/bundler.rb
-rw-r--r--  0 wheel  wheel    1354 Aug  4 21:17 lib/bootsnap/compile_cache.rb
-rw-r--r--  0 wheel  wheel    2096 Aug  4 21:17 lib/bootsnap/compile_cache/iseq.rb
-rw-r--r--  0 wheel  wheel    2031 Aug  4 21:17 lib/bootsnap/compile_cache/yaml.rb
-rw-r--r--  0 wheel  wheel    1484 Aug  4 21:17 lib/bootsnap/explicit_require.rb
-rw-r--r--  0 wheel  wheel    2682 Aug  4 21:17 lib/bootsnap/load_path_cache.rb
-rw-r--r--  0 wheel  wheel    6970 Aug  4 21:17 lib/bootsnap/load_path_cache/cache.rb
-rw-r--r--  0 wheel  wheel    2147 Aug  4 21:17 lib/bootsnap/load_path_cache/change_observer.rb
-rw-r--r--  0 wheel  wheel    4075 Aug  4 21:17 lib/bootsnap/load_path_cache/core_ext/active_support.rb
-rw-r--r--  0 wheel  wheel    3133 Aug  4 21:17 lib/bootsnap/load_path_cache/core_ext/kernel_require.rb
-rw-r--r--  0 wheel  wheel     518 Aug  4 21:17 lib/bootsnap/load_path_cache/core_ext/loaded_features.rb
-rw-r--r--  0 wheel  wheel    5460 Aug  4 21:17 lib/bootsnap/load_path_cache/loaded_features_index.rb
-rw-r--r--  0 wheel  wheel    3574 Aug  4 21:17 lib/bootsnap/load_path_cache/path.rb
-rw-r--r--  0 wheel  wheel    2231 Aug  4 21:17 lib/bootsnap/load_path_cache/path_scanner.rb
-rw-r--r--  0 wheel  wheel     721 Aug  4 21:17 lib/bootsnap/load_path_cache/realpath_cache.rb
-rw-r--r--  0 wheel  wheel    2620 Aug  4 21:17 lib/bootsnap/load_path_cache/store.rb
-rw-r--r--  0 wheel  wheel    1344 Aug  4 21:17 lib/bootsnap/setup.rb
-rw-r--r--  0 wheel  wheel      70 Aug  4 21:17 lib/bootsnap/version.rb

## Unpacked size

108004 bytes
```

</details>
