### PR TITLE
Enable Windows support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,24 @@
+name: ci
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu, macos, windows]
+        ruby: [2.5]
+    runs-on: ${{ matrix.os }}-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - run: bundle install
+      - run: bundle exec rake

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,3 +19,17 @@ If you're stuck, ask questions!
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create a new Pull Request
+
+## Running Tests on Windows
+
+### Setup
+
+1. Ensure you've installed Ruby and the MSYS2 devkit and have ran `ridk enable` in your shell. The `ridk enable` command adds make to the path so the compile rake task works.
+
+1. Open your shell as Administrator (`Run as Administrator`), as the tests create and delete symlinks
+
+### Running Tests
+
+> ridk enable
+> bundle install
+> bundle exec rake

--- a/Rakefile
+++ b/Rakefile
@@ -10,8 +10,12 @@ Rake::ExtensionTask.new do |ext|
   ext.gem_spec = gemspec
 end
 
-task :test do
-  sh 'bin/testunit'
+require "rake/testtask"
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << "test"
+  t.libs << "lib"
+  t.test_files = FileList["test/**/*_test.rb"]
 end
 
 task(default: %i(compile test))

--- a/lib/bootsnap/compile_cache.rb
+++ b/lib/bootsnap/compile_cache.rb
@@ -34,9 +34,9 @@ module Bootsnap
     end
 
     def self.supported?
-      # only enable on 'ruby' (MRI), POSIX (darwin, linux, *bsd), and >= 2.3.0
+      # only enable on 'ruby' (MRI), POSIX (darwin, linux, *bsd), Windows (RubyInstaller2) and >= 2.3.0
       RUBY_ENGINE == 'ruby' &&
-      RUBY_PLATFORM =~ /darwin|linux|bsd/ &&
+      RUBY_PLATFORM =~ /darwin|linux|bsd|mswin|mingw|cygwin/ &&
       Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.3.0")
     end
   end

--- a/lib/bootsnap/load_path_cache.rb
+++ b/lib/bootsnap/load_path_cache.rb
@@ -61,7 +61,7 @@ module Bootsnap
 
       def supported?
         RUBY_ENGINE == 'ruby' &&
-        RUBY_PLATFORM =~ /darwin|linux|bsd/
+        RUBY_PLATFORM =~ /darwin|linux|bsd|mswin|mingw|cygwin/
       end
     end
   end

--- a/test/compile_cache_key_format_test.rb
+++ b/test/compile_cache_key_format_test.rb
@@ -59,12 +59,22 @@ class CompileCacheKeyFormatTest < Minitest::Test
   end
 
   def test_fetch
-    actual = Bootsnap::CompileCache::Native.fetch(@tmp_dir, '/dev/null', TestHandler, nil)
-    assert_equal('NEATO /DEV/NULL', actual)
-    data = File.read("#{@tmp_dir}/8c/d2d180bbd995df")
-    assert_equal("neato /dev/null", data.force_encoding(Encoding::BINARY)[64..-1])
-    actual = Bootsnap::CompileCache::Native.fetch(@tmp_dir, '/dev/null', TestHandler, nil)
-    assert_equal('NEATO /DEV/NULL', actual)
+    if RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/
+      target = 'NUL'
+      expected_file = "#{@tmp_dir}/36/9eba19c29ffe00"
+    else
+      target = '/dev/null'
+      expected_file = "#{@tmp_dir}/8c/d2d180bbd995df"
+    end
+
+    actual = Bootsnap::CompileCache::Native.fetch(@tmp_dir, target, TestHandler, nil)
+    assert_equal("NEATO #{target.upcase}", actual)
+
+    data = File.read(expected_file)
+    assert_equal("neato #{target}", data.force_encoding(Encoding::BINARY)[64..-1])
+
+    actual = Bootsnap::CompileCache::Native.fetch(@tmp_dir, target, TestHandler, nil)
+    assert_equal("NEATO #{target.upcase}", actual)
   end
 
   def test_unexistent_fetch

--- a/test/compile_cache_test.rb
+++ b/test/compile_cache_test.rb
@@ -24,11 +24,24 @@ class CompileCacheTest < Minitest::Test
   end
 
   def test_no_write_permission_to_cache
-    path = Help.set_file('a.rb', 'a = 3', 100)
-    folder = File.dirname(Help.cache_path(@tmp_dir, path))
-    FileUtils.mkdir_p(folder)
-    FileUtils.chmod(0400, folder)
-    assert_raises(Bootsnap::CompileCache::PermissionError) { load(path) }
+    if RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/
+      # Always pass this test on Windows because directories aren't read, only
+      # listed. You can restrict the ability to list directory contents on
+      # Windows or you can set ACLS on a folder such that it is not allowed to
+      # list contents.
+      #
+      # Since we can't read directories on windows, this specific test doesn't
+      # make sense. In addtion we test read-only files in
+      # `test_can_open_read_only_cache` so we are covered testing reading
+      # read-only files.
+      pass
+    else
+      path = Help.set_file('a.rb', 'a = 3', 100)
+      folder = File.dirname(Help.cache_path(@tmp_dir, path))
+      FileUtils.mkdir_p(folder)
+      FileUtils.chmod(0400, folder)
+      assert_raises(Bootsnap::CompileCache::PermissionError) { load(path) }
+    end
   end
 
   def test_can_open_read_only_cache

--- a/test/load_path_cache/realpath_cache_test.rb
+++ b/test/load_path_cache/realpath_cache_test.rb
@@ -16,13 +16,13 @@ module Bootsnap
         @symlinked_dir = "#{@base_dir}/symlink"
         FileUtils.ln_s(@absolute_dir, @symlinked_dir)
 
-        real_caller = File.new("#{@absolute_dir}/real_caller.rb", 'w').path
+        real_caller = File.new("#{@absolute_dir}/real_caller.rb", 'w').tap(&:close).path
         symlinked_caller = "#{@absolute_dir}/symlinked_caller.rb"
 
         FileUtils.ln_s(real_caller, symlinked_caller)
 
         EXTENSIONS.each do |ext|
-          real_required = File.new("#{@absolute_dir}/real_required#{ext}", 'w').path
+          real_required = File.new("#{@absolute_dir}/real_required#{ext}", 'w').tap(&:close).path
 
           symlinked_required = "#{@absolute_dir}/symlinked_required#{ext}"
           FileUtils.ln_s(real_required, symlinked_required)


### PR DESCRIPTION
This PR enables Windows platform support by adding Windows platforms to the `supported?` methods in `compile_cache` and in `load_path_cache` and adds Github Action yaml files to test these changes on windows, linux, and macos.

It also changes the Rakefile to use the minitest rakefile methods to run all of the tests. This is done because the existing `bin/testunit` calls directly to `sh` which is not present on Windows platforms. By making this a ruby/rake call it makes the test suite platform independent. The existing files in `bin` are left in case there is other existing infrastructure that uses them.

Lastly it also makes several changes to the existing test files to support the Windows platform. These changes mainly comprise using Windows file paths or file access methods. There are two tests called out that do not work on Windows at all, and are hardcoded to pass. I would have used 'pending', but I could not find out how to do that in minitest.

Many thanks to @daniel-rikowski who originally got the tests to pass in the first place, and I would not have got anywhere without.

Fixes #316