### PR TITLE
CompileCache::YAML add support for symbolize_names and freeze options

### DIFF
--- a/lib/bootsnap/compile_cache/iseq.rb
+++ b/lib/bootsnap/compile_cache/iseq.rb
@@ -9,13 +9,13 @@ module Bootsnap
         attr_accessor(:cache_dir)
       end
 
-      def self.input_to_storage(_, path)
+      def self.input_to_storage(_, path, _args)
         RubyVM::InstructionSequence.compile_file(path).to_binary
       rescue SyntaxError
         raise(Uncompilable, 'syntax error')
       end
 
-      def self.storage_to_output(binary)
+      def self.storage_to_output(binary, _args)
         RubyVM::InstructionSequence.load_from_binary(binary)
       rescue RuntimeError => e
         if e.message == 'broken binary format'
@@ -26,7 +26,7 @@ module Bootsnap
         end
       end
 
-      def self.input_to_output(_)
+      def self.input_to_output(_, _)
         nil # ruby handles this
       end
 
@@ -38,7 +38,8 @@ module Bootsnap
           Bootsnap::CompileCache::Native.fetch(
             Bootsnap::CompileCache::ISeq.cache_dir,
             path.to_s,
-            Bootsnap::CompileCache::ISeq
+            Bootsnap::CompileCache::ISeq,
+            nil,
           )
         rescue Errno::EACCES
           Bootsnap::CompileCache.permission_error(path)

--- a/lib/bootsnap/compile_cache/yaml.rb
+++ b/lib/bootsnap/compile_cache/yaml.rb
@@ -5,56 +5,84 @@ module Bootsnap
   module CompileCache
     module YAML
       class << self
-        attr_accessor(:msgpack_factory)
-      end
+        attr_accessor(:msgpack_factory, :cache_dir, :supported_options)
 
-      def self.input_to_storage(contents, _)
-        raise(Uncompilable) if contents.index("!ruby/object")
-        obj = ::YAML.load(contents)
-        msgpack_factory.packer.write(obj).to_s
-      rescue NoMethodError, RangeError
-        # if the object included things that we can't serialize, fall back to
-        # Marshal. It's a bit slower, but can encode anything yaml can.
-        # NoMethodError is unexpected types; RangeError is Bignums
-        Marshal.dump(obj)
-      end
+        def input_to_storage(contents, _, kwargs)
+          raise(Uncompilable) if contents.index("!ruby/object")
+          obj = ::YAML.load(contents, **(kwargs || {}))
+          msgpack_factory.dump(obj)
+        rescue NoMethodError, RangeError
+          # if the object included things that we can't serialize, fall back to
+          # Marshal. It's a bit slower, but can encode anything yaml can.
+          # NoMethodError is unexpected types; RangeError is Bignums
+          Marshal.dump(obj)
+        end
 
-      def self.storage_to_output(data)
-        # This could have a meaning in messagepack, and we're being a little lazy
-        # about it. -- but a leading 0x04 would indicate the contents of the YAML
-        # is a positive integer, which is rare, to say the least.
-        if data[0] == 0x04.chr && data[1] == 0x08.chr
-          Marshal.load(data)
-        else
-          msgpack_factory.unpacker.feed(data).read
+        def storage_to_output(data, kwargs)
+          # This could have a meaning in messagepack, and we're being a little lazy
+          # about it. -- but a leading 0x04 would indicate the contents of the YAML
+          # is a positive integer, which is rare, to say the least.
+          if data[0] == 0x04.chr && data[1] == 0x08.chr
+            Marshal.load(data)
+          else
+            msgpack_factory.load(data, **(kwargs || {}))
+          end
+        end
+
+        def input_to_output(data, kwargs)
+          ::YAML.load(data, **(kwargs || {}))
+        end
+
+        def install!(cache_dir)
+          self.cache_dir = cache_dir
+          init!
+          ::YAML.singleton_class.prepend(Patch)
+        end
+
+        def init!
+          require('yaml')
+          require('msgpack')
+
+          # MessagePack serializes symbols as strings by default.
+          # We want them to roundtrip cleanly, so we use a custom factory.
+          # see: https://github.com/msgpack/msgpack-ruby/pull/122
+          factory = MessagePack::Factory.new
+          factory.register_type(0x00, Symbol)
+          self.msgpack_factory = factory
+
+          self.supported_options = []
+          params = ::YAML.method(:load).parameters
+          if params.include?([:key, :symbolize_names])
+            self.supported_options << :symbolize_names
+          end
+          if params.include?([:key, :freeze])
+            if factory.load(factory.dump('yaml'), freeze: true).frozen?
+              self.supported_options << :freeze
+            end
+          end
+          self.supported_options.freeze
         end
       end
 
-      def self.input_to_output(data)
-        ::YAML.load(data)
-      end
+      module Patch
+        extend self
 
-      def self.install!(cache_dir)
-        require('yaml')
-        require('msgpack')
+        def load_file(path, *args)
+          return super if args.size > 1
+          if kwargs = args.first
+            return super unless kwargs.is_a?(Hash)
+            return super unless (kwargs.keys - ::Bootsnap::CompileCache::YAML.supported_options).empty?
+          end
 
-        # MessagePack serializes symbols as strings by default.
-        # We want them to roundtrip cleanly, so we use a custom factory.
-        # see: https://github.com/msgpack/msgpack-ruby/pull/122
-        factory = MessagePack::Factory.new
-        factory.register_type(0x00, Symbol)
-        Bootsnap::CompileCache::YAML.msgpack_factory = factory
-
-        klass = class << ::YAML; self; end
-        klass.send(:define_method, :load_file) do |path|
           begin
-            Bootsnap::CompileCache::Native.fetch(
-              cache_dir,
+            ::Bootsnap::CompileCache::Native.fetch(
+              Bootsnap::CompileCache::YAML.cache_dir,
               path,
-              Bootsnap::CompileCache::YAML
+              ::Bootsnap::CompileCache::YAML,
+              kwargs,
             )
           rescue Errno::EACCES
-            Bootsnap::CompileCache.permission_error(path)
+            ::Bootsnap::CompileCache.permission_error(path)
           end
         end
       end

--- a/test/compile_cache/yaml_test.rb
+++ b/test/compile_cache/yaml_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+require('test_helper')
+
+class CompileCacheYAMLTest < Minitest::Test
+  include(TmpdirHelper)
+
+  def setup
+    super
+    Bootsnap::CompileCache::YAML.init!
+  end
+
+  def test_load_file
+    Help.set_file('a.yml', "---\nfoo: bar", 100)
+    assert_equal({'foo' => 'bar'}, Bootsnap::CompileCache::YAML::Patch.load_file('a.yml'))
+  end
+
+  def test_load_file_symbolize_names
+    Help.set_file('a.yml', "---\nfoo: bar", 100)
+    Bootsnap::CompileCache::YAML::Patch.load_file('a.yml')
+
+    if ::Bootsnap::CompileCache::YAML.supported_options.include?(:symbolize_names)
+      2.times do
+        assert_equal({foo: 'bar'}, Bootsnap::CompileCache::YAML::Patch.load_file('a.yml', symbolize_names: true))
+      end
+    else
+      assert_raises(NoMethodError) do # would call super
+        Bootsnap::CompileCache::YAML::Patch.load_file('a.yml', symbolize_names: true)
+      end
+    end
+  end
+
+  def test_load_file_freeze
+    Help.set_file('a.yml', "---\nfoo", 100)
+    Bootsnap::CompileCache::YAML::Patch.load_file('a.yml')
+
+    if ::Bootsnap::CompileCache::YAML.supported_options.include?(:freeze)
+      2.times do
+        string = Bootsnap::CompileCache::YAML::Patch.load_file('a.yml', freeze: true)
+        assert_equal("foo", string)
+        assert_predicate(string, :frozen?)
+      end
+    else
+      assert_raises(NoMethodError) do # would call super
+        Bootsnap::CompileCache::YAML::Patch.load_file('a.yml', freeze: true)
+      end
+    end
+  end
+
+  def test_load_file_unknown_option
+    Help.set_file('a.yml', "---\nfoo", 100)
+    Bootsnap::CompileCache::YAML::Patch.load_file('a.yml')
+
+    assert_raises(NoMethodError) do # would call super
+      Bootsnap::CompileCache::YAML::Patch.load_file('a.yml', unknown: true)
+    end
+  end
+end

--- a/test/compile_cache_handler_errors_test.rb
+++ b/test/compile_cache_handler_errors_test.rb
@@ -19,7 +19,7 @@ class CompileCacheHandlerErrorsTest < Minitest::Test
   def test_input_to_storage_invalid_instance_of_expected_type
     path = Help.set_file('a.rb', 'a = 3', 100)
     Bootsnap::CompileCache::ISeq.expects(:input_to_storage).returns('broken')
-    Bootsnap::CompileCache::ISeq.expects(:input_to_output).with('a = 3').returns('whatever')
+    Bootsnap::CompileCache::ISeq.expects(:input_to_output).with('a = 3', nil).returns('whatever')
     _, err = capture_subprocess_io do
       load(path)
     end

--- a/test/compile_cache_key_format_test.rb
+++ b/test/compile_cache_key_format_test.rb
@@ -59,24 +59,24 @@ class CompileCacheKeyFormatTest < Minitest::Test
   end
 
   def test_fetch
-    actual = Bootsnap::CompileCache::Native.fetch(@tmp_dir, '/dev/null', TestHandler)
+    actual = Bootsnap::CompileCache::Native.fetch(@tmp_dir, '/dev/null', TestHandler, nil)
     assert_equal('NEATO /DEV/NULL', actual)
     data = File.read("#{@tmp_dir}/8c/d2d180bbd995df")
     assert_equal("neato /dev/null", data.force_encoding(Encoding::BINARY)[64..-1])
-    actual = Bootsnap::CompileCache::Native.fetch(@tmp_dir, '/dev/null', TestHandler)
+    actual = Bootsnap::CompileCache::Native.fetch(@tmp_dir, '/dev/null', TestHandler, nil)
     assert_equal('NEATO /DEV/NULL', actual)
   end
 
   def test_unexistent_fetch
     assert_raises(Errno::ENOENT) do
-      Bootsnap::CompileCache::Native.fetch(@tmp_dir, '123', Bootsnap::CompileCache::ISeq)
+      Bootsnap::CompileCache::Native.fetch(@tmp_dir, '123', Bootsnap::CompileCache::ISeq, nil)
     end
   end
 
   private
 
   def cache_key_for_file(file)
-    Bootsnap::CompileCache::Native.fetch(@tmp_dir, file, TestHandler)
+    Bootsnap::CompileCache::Native.fetch(@tmp_dir, file, TestHandler, nil)
     data = File.read(Help.cache_path(@tmp_dir, file))
     Help.binary(data[0..31])
   end


### PR DESCRIPTION
So far the YAML cache has been simple enough to implement because `YAML.load_file` pretty much only take a single parameter. However it's mostly an oversight. Psych `3.1` added a `symbolize_names:` options to `load`, and `3.2` a `freeze:` option.

In https://github.com/ruby/psych/pull/463 I'm requesting these options to be forwarded.

For `symbolize_keys` it's easy since message pack already has the same option since a very long time, and anyway it supports symbols so that will work transparently.

`freeze` is a bit more tricky, as `MessagePack` need to do the same thing. I have a PR for that https://github.com/msgpack/msgpack-ruby/pull/194 and the maintainer agreed on it, so it should land at some point. So with a bit of feature testing we're fine.

On another note, it's not yet released, but [`json` added a `load_file` method as well](https://github.com/flori/json/pull/387) which I'd like to add supports for, and it takes options too. So this change is kind of a two birds one stone.
