### PR TITLE
Update input_to_output method arguments to use dissimilar names

### DIFF
--- a/lib/bootsnap/compile_cache/iseq.rb
+++ b/lib/bootsnap/compile_cache/iseq.rb
@@ -35,7 +35,7 @@ module Bootsnap
         )
       end
 
-      def self.input_to_output(_, _)
+      def self.input_to_output(_data, _kwargs)
         nil # ruby handles this
       end
 


### PR DESCRIPTION
This method using `_` for both arguments was causing Sorbet to fail when generating type information (https://github.com/sorbet/sorbet/issues/3561). This change doesn't modify any functionality or outward API in the gem itself. The argument names are based on the arguments for `input_to_output` in `lib/bootsnap/compile_cache/yaml.rb`.