### PR TITLE
Use a more manageable cache directory structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+* Changed the load path cache directory from `$BOOTSNAP_CACHE_DIR/bootsnap-load-path-cache` to `$BOOTSNAP_CACHE_DIR/bootsnap/load-path-cache` for ease of use (#334)
+* Changed the compile cache directory from `$BOOTSNAP_CACHE_DIR/bootsnap-compile-cache` to `$BOOTSNAP_CACHE_DIR/bootsnap/compile-cache` for ease of use (#334)
+
 # 1.5.1
 
 * Workaround a Ruby bug in InstructionSequence.compile_file. (#332)

--- a/lib/bootsnap.rb
+++ b/lib/bootsnap.rb
@@ -24,13 +24,13 @@ module Bootsnap
     setup_disable_trace if disable_trace
 
     Bootsnap::LoadPathCache.setup(
-      cache_path:       cache_dir + '/bootsnap-load-path-cache',
+      cache_path:       cache_dir + '/bootsnap/load-path-cache',
       development_mode: development_mode,
       active_support:   autoload_paths_cache
     ) if load_path_cache
 
     Bootsnap::CompileCache.setup(
-      cache_dir: cache_dir + '/bootsnap-compile-cache',
+      cache_dir: cache_dir + '/bootsnap/compile-cache',
       iseq: compile_cache_iseq,
       yaml: compile_cache_yaml
     )

--- a/lib/bootsnap/cli.rb
+++ b/lib/bootsnap/cli.rb
@@ -114,7 +114,7 @@ module Bootsnap
     end
 
     def cache_dir=(dir)
-      @cache_dir = File.expand_path(File.join(dir, 'bootsnap-compile-cache'))
+      @cache_dir = File.expand_path(File.join(dir, 'bootsnap/compile-cache'))
     end
 
     def parser

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -8,7 +8,7 @@ module Bootsnap
 
     def setup
       super
-      @cache_dir = File.expand_path('tmp/cache/bootsnap-compile-cache')
+      @cache_dir = File.expand_path('tmp/cache/bootsnap/compile-cache')
     end
 
     def test_precompile_single_file

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,7 +10,7 @@ require('fileutils')
 require('minitest/autorun')
 require('mocha/minitest')
 
-cache_dir = File.expand_path('../../tmp/bootsnap-compile-cache', __FILE__)
+cache_dir = File.expand_path('../../tmp/bootsnap/compile-cache', __FILE__)
 Bootsnap::CompileCache.setup(cache_dir: cache_dir, iseq: true, yaml: false)
 
 module TestHandler


### PR DESCRIPTION
The current cache paths are:

 - `<DIR>/bootsnap-load-path-cache`
 - `<DIR>/bootsnap-compile-cache`

This structure is annoying when you are working on CI systems where you need to specify the paths that need to be persisted across builds, and similar scenarios.

I propose to change it for:

- `<DIR>/bootsnap/load-path-cache`
- `<DIR>/bootsnap/compile-cache`

Making it easier to manage.

On bit problem though is that this change might break some people's workflow, as it's not uncommon to have various script to delete / persist / etc the cache.

@rafaelfranca what do you think?
cc @Shopify/rails 