### PR TITLE
YAML cache: freeze option should not change the cache key

### DIFF
--- a/ext/bootsnap/bootsnap.c
+++ b/ext/bootsnap/bootsnap.c
@@ -91,7 +91,7 @@ static ID uncompilable;
 
 /* Functions exposed as module functions on Bootsnap::CompileCache::Native */
 static VALUE bs_compile_option_crc32_set(VALUE self, VALUE crc32_v);
-static VALUE bs_rb_fetch(VALUE self, VALUE cachedir_v, VALUE path_v, VALUE handler, VALUE args);
+static VALUE bs_rb_fetch(VALUE self, VALUE cachedir_v, VALUE path_v, VALUE handler, VALUE args, VALUE args_key);
 
 /* Helpers */
 static uint64_t fnv1a_64(const char *str);
@@ -148,7 +148,7 @@ Init_bootsnap(void)
   uncompilable = rb_intern("__bootsnap_uncompilable__");
 
   rb_define_module_function(rb_mBootsnap_CompileCache_Native, "coverage_running?", bs_rb_coverage_running, 0);
-  rb_define_module_function(rb_mBootsnap_CompileCache_Native, "fetch", bs_rb_fetch, 4);
+  rb_define_module_function(rb_mBootsnap_CompileCache_Native, "fetch", bs_rb_fetch, 5);
   rb_define_module_function(rb_mBootsnap_CompileCache_Native, "compile_option_crc32=", bs_compile_option_crc32_set, 1);
 
   current_umask = umask(0777);
@@ -304,7 +304,7 @@ cache_key_equal(struct bs_cache_key * k1, struct bs_cache_key * k2)
  * conversions on the ruby VALUE arguments before passing them along.
  */
 static VALUE
-bs_rb_fetch(VALUE self, VALUE cachedir_v, VALUE path_v, VALUE handler, VALUE args)
+bs_rb_fetch(VALUE self, VALUE cachedir_v, VALUE path_v, VALUE handler, VALUE args, VALUE args_key)
 {
   FilePathValue(path_v);
 
@@ -319,9 +319,10 @@ bs_rb_fetch(VALUE self, VALUE cachedir_v, VALUE path_v, VALUE handler, VALUE arg
   char * path     = RSTRING_PTR(path_v);
   char cache_path[MAX_CACHEPATH_SIZE];
   char * extra    = NULL;
-  if (!NIL_P(args)) {
-    VALUE args_serial = rb_marshal_dump(args, Qnil);
-    extra = RSTRING_PTR(args_serial);
+
+  if (!NIL_P(args_key)) {
+    Check_Type(args_key, T_STRING);
+    extra = RSTRING_PTR(args_key);
   }
 
   /* generate cache path to cache_path */

--- a/lib/bootsnap/compile_cache/iseq.rb
+++ b/lib/bootsnap/compile_cache/iseq.rb
@@ -32,6 +32,7 @@ module Bootsnap
           path.to_s,
           Bootsnap::CompileCache::ISeq,
           nil,
+          nil,
         )
       end
 

--- a/lib/bootsnap/compile_cache/yaml.rb
+++ b/lib/bootsnap/compile_cache/yaml.rb
@@ -74,12 +74,21 @@ module Bootsnap
             return super unless (kwargs.keys - ::Bootsnap::CompileCache::YAML.supported_options).empty?
           end
 
+          args_key = nil
+          if kwargs && kwargs[:symbolize_names]
+            # symbolize_names and freeze are the only two supported options.
+            # But freeze doesn't impact the cache, so symbolize_names is the only
+            # one that needs to be part of the cache key
+            args_key = 'symbolize_names=true'
+          end
+
           begin
             ::Bootsnap::CompileCache::Native.fetch(
               Bootsnap::CompileCache::YAML.cache_dir,
               path,
               ::Bootsnap::CompileCache::YAML,
               kwargs,
+              args_key,
             )
           rescue Errno::EACCES
             ::Bootsnap::CompileCache.permission_error(path)

--- a/test/compile_cache_key_format_test.rb
+++ b/test/compile_cache_key_format_test.rb
@@ -67,26 +67,26 @@ class CompileCacheKeyFormatTest < Minitest::Test
       expected_file = "#{@tmp_dir}/8c/d2d180bbd995df"
     end
 
-    actual = Bootsnap::CompileCache::Native.fetch(@tmp_dir, target, TestHandler, nil)
+    actual = Bootsnap::CompileCache::Native.fetch(@tmp_dir, target, TestHandler, nil, nil)
     assert_equal("NEATO #{target.upcase}", actual)
 
     data = File.read(expected_file)
     assert_equal("neato #{target}", data.force_encoding(Encoding::BINARY)[64..-1])
 
-    actual = Bootsnap::CompileCache::Native.fetch(@tmp_dir, target, TestHandler, nil)
+    actual = Bootsnap::CompileCache::Native.fetch(@tmp_dir, target, TestHandler, nil, nil)
     assert_equal("NEATO #{target.upcase}", actual)
   end
 
   def test_unexistent_fetch
     assert_raises(Errno::ENOENT) do
-      Bootsnap::CompileCache::Native.fetch(@tmp_dir, '123', Bootsnap::CompileCache::ISeq, nil)
+      Bootsnap::CompileCache::Native.fetch(@tmp_dir, '123', Bootsnap::CompileCache::ISeq, nil, nil)
     end
   end
 
   private
 
   def cache_key_for_file(file)
-    Bootsnap::CompileCache::Native.fetch(@tmp_dir, file, TestHandler, nil)
+    Bootsnap::CompileCache::Native.fetch(@tmp_dir, file, TestHandler, nil, nil)
     data = File.read(Help.cache_path(@tmp_dir, file))
     Help.binary(data[0..31])
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -51,10 +51,10 @@ module MiniTest
           str.force_encoding(Encoding::BINARY)
         end
 
-        def cache_path(dir, file, args = nil)
+        def cache_path(dir, file, args_key = nil)
           hash = fnv1a_64(file)
-          unless args.nil?
-            hash ^= fnv1a_64(Marshal.dump(args))
+          unless args_key.nil?
+            hash ^= fnv1a_64(args_key)
           end
 
           hex = hash.to_s(16)


### PR DESCRIPTION
If you use `symbolize_names` the msgpack cache will be different, so the cache key has to be different. However `freeze` won't change the cache at all.