### PR TITLE
CLI: also precompile YAML cache

### DIFF
--- a/lib/bootsnap/compile_cache/iseq.rb
+++ b/lib/bootsnap/compile_cache/iseq.rb
@@ -36,6 +36,14 @@ module Bootsnap
         )
       end
 
+      def self.precompile(path, cache_dir: ISeq.cache_dir)
+        Bootsnap::CompileCache::Native.precompile(
+          cache_dir,
+          path.to_s,
+          Bootsnap::CompileCache::ISeq,
+        )
+      end
+
       def self.input_to_output(_data, _kwargs)
         nil # ruby handles this
       end

--- a/lib/bootsnap/compile_cache/yaml.rb
+++ b/lib/bootsnap/compile_cache/yaml.rb
@@ -23,7 +23,13 @@ module Bootsnap
           # about it. -- but a leading 0x04 would indicate the contents of the YAML
           # is a positive integer, which is rare, to say the least.
           if data[0] == 0x04.chr && data[1] == 0x08.chr
-            Marshal.load(data)
+            begin
+              Marshal.load(data)
+            rescue ArgumentError => e
+              p e
+              p data
+              raise
+            end
           else
             msgpack_factory.load(data, **(kwargs || {}))
           end
@@ -31,6 +37,14 @@ module Bootsnap
 
         def input_to_output(data, kwargs)
           ::YAML.load(data, **(kwargs || {}))
+        end
+
+        def precompile(path, cache_dir: YAML.cache_dir)
+          Bootsnap::CompileCache::Native.precompile(
+            cache_dir,
+            path.to_s,
+            Bootsnap::CompileCache::YAML,
+          )
         end
 
         def install!(cache_dir)

--- a/lib/bootsnap/compile_cache/yaml.rb
+++ b/lib/bootsnap/compile_cache/yaml.rb
@@ -23,13 +23,7 @@ module Bootsnap
           # about it. -- but a leading 0x04 would indicate the contents of the YAML
           # is a positive integer, which is rare, to say the least.
           if data[0] == 0x04.chr && data[1] == 0x08.chr
-            begin
-              Marshal.load(data)
-            rescue ArgumentError => e
-              p e
-              p data
-              raise
-            end
+            Marshal.load(data)
           else
             msgpack_factory.load(data, **(kwargs || {}))
           end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -13,16 +13,22 @@ module Bootsnap
 
     def test_precompile_single_file
       path = Help.set_file('a.rb', 'a = a = 3', 100)
-      CompileCache::ISeq.expects(:fetch).with(File.expand_path(path), cache_dir: @cache_dir)
+      CompileCache::ISeq.expects(:precompile).with(File.expand_path(path), cache_dir: @cache_dir)
       assert_equal 0, CLI.new(['precompile', path]).run
+    end
+
+    def test_no_iseq
+      path = Help.set_file('a.rb', 'a = a = 3', 100)
+      CompileCache::ISeq.expects(:precompile).never
+      assert_equal 0, CLI.new(['precompile', '--no-iseq', path]).run
     end
 
     def test_precompile_directory
       path_a = Help.set_file('foo/a.rb', 'a = a = 3', 100)
       path_b = Help.set_file('foo/b.rb', 'b = b = 3', 100)
 
-      CompileCache::ISeq.expects(:fetch).with(File.expand_path(path_a), cache_dir: @cache_dir)
-      CompileCache::ISeq.expects(:fetch).with(File.expand_path(path_b), cache_dir: @cache_dir)
+      CompileCache::ISeq.expects(:precompile).with(File.expand_path(path_a), cache_dir: @cache_dir)
+      CompileCache::ISeq.expects(:precompile).with(File.expand_path(path_b), cache_dir: @cache_dir)
       assert_equal 0, CLI.new(['precompile', 'foo']).run
     end
 
@@ -30,12 +36,24 @@ module Bootsnap
       path_a = Help.set_file('foo/a.rb', 'a = a = 3', 100)
       Help.set_file('foo/b.rb', 'b = b = 3', 100)
 
-      CompileCache::ISeq.expects(:fetch).with(File.expand_path(path_a), cache_dir: @cache_dir)
+      CompileCache::ISeq.expects(:precompile).with(File.expand_path(path_a), cache_dir: @cache_dir)
       assert_equal 0, CLI.new(['precompile', '--exclude', 'b.rb', 'foo']).run
     end
 
     def test_precompile_gemfile
       assert_equal 0, CLI.new(['precompile', '--gemfile']).run
+    end
+
+    def test_precompile_yaml
+      path = Help.set_file('a.yaml', 'foo: bar', 100)
+      CompileCache::YAML.expects(:precompile).with(File.expand_path(path), cache_dir: @cache_dir)
+      assert_equal 0, CLI.new(['precompile', path]).run
+    end
+
+    def test_no_yaml
+      path = Help.set_file('a.yaml', 'foo: bar', 100)
+      CompileCache::YAML.expects(:precompile).never
+      assert_equal 0, CLI.new(['precompile', '--no-yaml', path]).run
     end
   end
 end


### PR DESCRIPTION
On some apps, the YAML cache is also a big part of boot performance. Ideally the `precompile` CLI should precompile YAML caches as well. 

