### PR TITLE
CLI: multi process to speed up precompilation

### DIFF
--- a/lib/bootsnap/cli/worker_pool.rb
+++ b/lib/bootsnap/cli/worker_pool.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+module Bootsnap
+  class CLI
+    class WorkerPool
+      class << self
+        def create(size:, jobs:)
+          if size > 0 && Process.respond_to?(:fork)
+            new(size: size, jobs: jobs)
+          else
+            Inline.new(jobs: jobs)
+          end
+        end
+      end
+
+      class Inline
+        def initialize(jobs: {})
+          @jobs = jobs
+        end
+
+        def push(job, *args)
+          @jobs.fetch(job).call(*args)
+          nil
+        end
+
+        def spawn
+          # noop
+        end
+
+        def shutdown
+          # noop
+        end
+      end
+
+      class Worker
+        attr_reader :to_io, :pid
+
+        def initialize(jobs)
+          @jobs = jobs
+          @pipe_out, @to_io = IO.pipe
+          @pid = nil
+        end
+
+        def write(message, block: true)
+          payload = Marshal.dump(message)
+          if block
+            to_io.write(payload)
+            true
+          else
+            to_io.write_nonblock(payload, exception: false) != :wait_writable
+          end
+        end
+
+        def close
+          to_io.close
+        end
+
+        def work_loop
+          loop do
+            job, *args = Marshal.load(@pipe_out)
+            return if job == :exit
+            @jobs.fetch(job).call(*args)
+          end
+        rescue IOError
+          nil
+        end
+
+        def spawn
+          @pid = Process.fork do
+            to_io.close
+            work_loop
+            exit!(0)
+          end
+          @pipe_out.close
+          true
+        end
+      end
+
+      def initialize(size:, jobs: {})
+        @size = size
+        @jobs = jobs
+        @queue = Queue.new
+        @pids = []
+      end
+
+      def spawn
+        @workers = @size.times.map { Worker.new(@jobs) }
+        @workers.each(&:spawn)
+        @dispatcher_thread = Thread.new { dispatch_loop }
+        @dispatcher_thread.abort_on_exception = true
+        true
+      end
+
+      def dispatch_loop
+        loop do
+          case job = @queue.pop
+          when nil
+            @workers.each do |worker|
+              worker.write([:exit])
+              worker.close
+            end
+            return true
+          else
+            unless @workers.sample.write(job, block: false)
+              free_worker.write(job)
+            end
+          end
+        end
+      end
+
+      def free_worker
+        IO.select(nil, @workers)[1].sample
+      end
+
+      def push(*args)
+        @queue.push(args)
+        nil
+      end
+
+      def shutdown
+        @queue.close
+        @dispatcher_thread.join
+        @workers.each do |worker|
+          _pid, status = Process.wait2(worker.pid)
+          return status.exitstatus unless status.success?
+        end
+        nil
+      end
+    end
+  end
+end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -14,13 +14,13 @@ module Bootsnap
     def test_precompile_single_file
       path = Help.set_file('a.rb', 'a = a = 3', 100)
       CompileCache::ISeq.expects(:precompile).with(File.expand_path(path), cache_dir: @cache_dir)
-      assert_equal 0, CLI.new(['precompile', path]).run
+      assert_equal 0, CLI.new(['precompile', '-j', '0', path]).run
     end
 
     def test_no_iseq
       path = Help.set_file('a.rb', 'a = a = 3', 100)
       CompileCache::ISeq.expects(:precompile).never
-      assert_equal 0, CLI.new(['precompile', '--no-iseq', path]).run
+      assert_equal 0, CLI.new(['precompile', '-j', '0', '--no-iseq', path]).run
     end
 
     def test_precompile_directory
@@ -29,7 +29,7 @@ module Bootsnap
 
       CompileCache::ISeq.expects(:precompile).with(File.expand_path(path_a), cache_dir: @cache_dir)
       CompileCache::ISeq.expects(:precompile).with(File.expand_path(path_b), cache_dir: @cache_dir)
-      assert_equal 0, CLI.new(['precompile', 'foo']).run
+      assert_equal 0, CLI.new(['precompile', '-j', '0', 'foo']).run
     end
 
     def test_precompile_exclude
@@ -37,7 +37,7 @@ module Bootsnap
       Help.set_file('foo/b.rb', 'b = b = 3', 100)
 
       CompileCache::ISeq.expects(:precompile).with(File.expand_path(path_a), cache_dir: @cache_dir)
-      assert_equal 0, CLI.new(['precompile', '--exclude', 'b.rb', 'foo']).run
+      assert_equal 0, CLI.new(['precompile', '-j', '0', '--exclude', 'b.rb', 'foo']).run
     end
 
     def test_precompile_gemfile
@@ -47,13 +47,13 @@ module Bootsnap
     def test_precompile_yaml
       path = Help.set_file('a.yaml', 'foo: bar', 100)
       CompileCache::YAML.expects(:precompile).with(File.expand_path(path), cache_dir: @cache_dir)
-      assert_equal 0, CLI.new(['precompile', path]).run
+      assert_equal 0, CLI.new(['precompile', '-j', '0', path]).run
     end
 
     def test_no_yaml
       path = Help.set_file('a.yaml', 'foo: bar', 100)
       CompileCache::YAML.expects(:precompile).never
-      assert_equal 0, CLI.new(['precompile', '--no-yaml', path]).run
+      assert_equal 0, CLI.new(['precompile', '-j', '0', '--no-yaml', path]).run
     end
   end
 end

--- a/test/worker_pool_test.rb
+++ b/test/worker_pool_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require('test_helper')
+require('bootsnap/cli')
+
+module Bootsnap
+  class WorkerPoolTestTest < Minitest::Test
+    def test_dispatch
+      @pool = CLI::WorkerPool.create(size: 2, jobs: { touch: ->(path) { File.write(path, $$.to_s) } })
+      @pool.spawn
+
+      Dir.mktmpdir('bootsnap-test') do |tmpdir|
+        10.times do |i|
+          @pool.push(:touch, File.join(tmpdir, i.to_s))
+        end
+
+        @pool.shutdown
+        files = Dir.chdir(tmpdir) { Dir['*'] }.sort
+        assert_equal 10.times.map(&:to_s), files
+      end
+    end
+  end
+end


### PR DESCRIPTION
Followup: https://github.com/Shopify/bootsnap/pull/340

Precompilation was already a bit slow on big repos, but now with the addition of YAML it's really getting out of hand, to the point of becoming the bottleneck in some of our pipelines.

However the workload is quite trivial to parallelize.

Both with an empty cache:

```bash
$ time bundle exec exe/bootsnap -j 0 precompile path/to/our/biggest/app

real	1m20.025s
user	0m39.232s
sys	0m17.783s
$ time bundle exec exe/bootsnap -j 4 precompile path/to/our/biggest/app

real	0m30.839s
user	0m40.813s
sys	0m20.051s
```

