### PR TITLE
Rework support for YAML symbolize_names and drop the Marshal fallback

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,5 @@ gemspec
 
 group :development do
   gem 'rubocop'
+  gem 'byebug', platform: :ruby
 end

--- a/lib/bootsnap/compile_cache/iseq.rb
+++ b/lib/bootsnap/compile_cache/iseq.rb
@@ -9,7 +9,7 @@ module Bootsnap
         attr_accessor(:cache_dir)
       end
 
-      def self.input_to_storage(_, path, _args)
+      def self.input_to_storage(_, path)
         RubyVM::InstructionSequence.compile_file(path).to_binary
       rescue SyntaxError
         raise(Uncompilable, 'syntax error')
@@ -31,7 +31,6 @@ module Bootsnap
           cache_dir,
           path.to_s,
           Bootsnap::CompileCache::ISeq,
-          nil,
           nil,
         )
       end

--- a/lib/bootsnap/compile_cache/yaml.rb
+++ b/lib/bootsnap/compile_cache/yaml.rb
@@ -7,26 +7,20 @@ module Bootsnap
       class << self
         attr_accessor(:msgpack_factory, :cache_dir, :supported_options)
 
-        def input_to_storage(contents, _, kwargs)
+        def input_to_storage(contents, _)
           raise(Uncompilable) if contents.index("!ruby/object")
-          obj = ::YAML.load(contents, **(kwargs || {}))
+          obj = ::YAML.load(contents)
           msgpack_factory.dump(obj)
         rescue NoMethodError, RangeError
-          # if the object included things that we can't serialize, fall back to
-          # Marshal. It's a bit slower, but can encode anything yaml can.
-          # NoMethodError is unexpected types; RangeError is Bignums
-          Marshal.dump(obj)
+          # The object included things that we can't serialize
+          raise(Uncompilable)
         end
 
         def storage_to_output(data, kwargs)
-          # This could have a meaning in messagepack, and we're being a little lazy
-          # about it. -- but a leading 0x04 would indicate the contents of the YAML
-          # is a positive integer, which is rare, to say the least.
-          if data[0] == 0x04.chr && data[1] == 0x08.chr
-            Marshal.load(data)
-          else
-            msgpack_factory.load(data, **(kwargs || {}))
+          if kwargs && kwargs.key?(:symbolize_names)
+            kwargs[:symbolize_keys] = kwargs.delete(:symbolize_names)
           end
+          msgpack_factory.load(data, kwargs)
         end
 
         def input_to_output(data, kwargs)
@@ -50,12 +44,31 @@ module Bootsnap
         def init!
           require('yaml')
           require('msgpack')
+          require('date')
 
           # MessagePack serializes symbols as strings by default.
           # We want them to roundtrip cleanly, so we use a custom factory.
           # see: https://github.com/msgpack/msgpack-ruby/pull/122
           factory = MessagePack::Factory.new
           factory.register_type(0x00, Symbol)
+          factory.register_type(
+            MessagePack::Timestamp::TYPE, # or just -1
+            Time,
+            packer: MessagePack::Time::Packer,
+            unpacker: MessagePack::Time::Unpacker
+          )
+
+          marshal_fallback = {
+            packer: ->(value) { Marshal.dump(value) },
+            unpacker: ->(payload) { Marshal.load(payload) },
+          }
+          {
+            Date => 0x01,
+            Regexp => 0x02,
+          }.each do |type, code|
+            factory.register_type(code, type, marshal_fallback)
+          end
+
           self.msgpack_factory = factory
 
           self.supported_options = []
@@ -73,21 +86,11 @@ module Bootsnap
       end
 
       module Patch
-        extend self
-
         def load_file(path, *args)
           return super if args.size > 1
           if kwargs = args.first
             return super unless kwargs.is_a?(Hash)
             return super unless (kwargs.keys - ::Bootsnap::CompileCache::YAML.supported_options).empty?
-          end
-
-          args_key = nil
-          if kwargs && kwargs[:symbolize_names]
-            # symbolize_names and freeze are the only two supported options.
-            # But freeze doesn't impact the cache, so symbolize_names is the only
-            # one that needs to be part of the cache key
-            args_key = 'symbolize_names=true'
           end
 
           begin
@@ -96,12 +99,13 @@ module Bootsnap
               path,
               ::Bootsnap::CompileCache::YAML,
               kwargs,
-              args_key,
             )
           rescue Errno::EACCES
             ::Bootsnap::CompileCache.permission_error(path)
           end
         end
+
+        ruby2_keywords :load_file if respond_to?(:ruby2_keywords, true)
       end
     end
   end

--- a/test/compile_cache/yaml_test.rb
+++ b/test/compile_cache/yaml_test.rb
@@ -4,6 +4,16 @@ require('test_helper')
 class CompileCacheYAMLTest < Minitest::Test
   include(TmpdirHelper)
 
+  module FakeYaml
+    Fallback = Class.new(StandardError)
+    extend self
+    singleton_class.prepend(Bootsnap::CompileCache::YAML::Patch)
+
+    def load_file(path, symbolize_names: false, freeze: false, fallback: nil)
+      raise Fallback
+    end
+  end
+
   def setup
     super
     Bootsnap::CompileCache::YAML.init!
@@ -11,47 +21,47 @@ class CompileCacheYAMLTest < Minitest::Test
 
   def test_load_file
     Help.set_file('a.yml', "---\nfoo: bar", 100)
-    assert_equal({'foo' => 'bar'}, Bootsnap::CompileCache::YAML::Patch.load_file('a.yml'))
+    assert_equal({'foo' => 'bar'}, FakeYaml.load_file('a.yml'))
   end
 
   def test_load_file_symbolize_names
     Help.set_file('a.yml', "---\nfoo: bar", 100)
-    Bootsnap::CompileCache::YAML::Patch.load_file('a.yml')
+    FakeYaml.load_file('a.yml')
 
     if ::Bootsnap::CompileCache::YAML.supported_options.include?(:symbolize_names)
       2.times do
-        assert_equal({foo: 'bar'}, Bootsnap::CompileCache::YAML::Patch.load_file('a.yml', symbolize_names: true))
+        assert_equal({foo: 'bar'}, FakeYaml.load_file('a.yml', symbolize_names: true))
       end
     else
-      assert_raises(NoMethodError) do # would call super
-        Bootsnap::CompileCache::YAML::Patch.load_file('a.yml', symbolize_names: true)
+      assert_raises(FakeYaml::Fallback) do # would call super
+        FakeYaml.load_file('a.yml', symbolize_names: true)
       end
     end
   end
 
   def test_load_file_freeze
     Help.set_file('a.yml', "---\nfoo", 100)
-    Bootsnap::CompileCache::YAML::Patch.load_file('a.yml')
+    FakeYaml.load_file('a.yml')
 
     if ::Bootsnap::CompileCache::YAML.supported_options.include?(:freeze)
       2.times do
-        string = Bootsnap::CompileCache::YAML::Patch.load_file('a.yml', freeze: true)
+        string = FakeYaml.load_file('a.yml', freeze: true)
         assert_equal("foo", string)
         assert_predicate(string, :frozen?)
       end
     else
-      assert_raises(NoMethodError) do # would call super
-        Bootsnap::CompileCache::YAML::Patch.load_file('a.yml', freeze: true)
+      assert_raises(FakeYaml::Fallback) do # would call super
+        FakeYaml.load_file('a.yml', freeze: true)
       end
     end
   end
 
   def test_load_file_unknown_option
     Help.set_file('a.yml', "---\nfoo", 100)
-    Bootsnap::CompileCache::YAML::Patch.load_file('a.yml')
+    FakeYaml.load_file('a.yml')
 
-    assert_raises(NoMethodError) do # would call super
-      Bootsnap::CompileCache::YAML::Patch.load_file('a.yml', unknown: true)
+    assert_raises(FakeYaml::Fallback) do # would call super
+      FakeYaml.load_file('a.yml', fallback: true)
     end
   end
 end

--- a/test/compile_cache_key_format_test.rb
+++ b/test/compile_cache_key_format_test.rb
@@ -19,7 +19,7 @@ class CompileCacheKeyFormatTest < Minitest::Test
 
   def test_key_version
     key = cache_key_for_file(__FILE__)
-    exp = [2].pack("L")
+    exp = [3].pack("L")
     assert_equal(exp, key[R[:version]])
   end
 
@@ -67,26 +67,26 @@ class CompileCacheKeyFormatTest < Minitest::Test
       expected_file = "#{@tmp_dir}/8c/d2d180bbd995df"
     end
 
-    actual = Bootsnap::CompileCache::Native.fetch(@tmp_dir, target, TestHandler, nil, nil)
+    actual = Bootsnap::CompileCache::Native.fetch(@tmp_dir, target, TestHandler, nil)
     assert_equal("NEATO #{target.upcase}", actual)
 
     data = File.read(expected_file)
     assert_equal("neato #{target}", data.force_encoding(Encoding::BINARY)[64..-1])
 
-    actual = Bootsnap::CompileCache::Native.fetch(@tmp_dir, target, TestHandler, nil, nil)
+    actual = Bootsnap::CompileCache::Native.fetch(@tmp_dir, target, TestHandler, nil)
     assert_equal("NEATO #{target.upcase}", actual)
   end
 
   def test_unexistent_fetch
     assert_raises(Errno::ENOENT) do
-      Bootsnap::CompileCache::Native.fetch(@tmp_dir, '123', Bootsnap::CompileCache::ISeq, nil, nil)
+      Bootsnap::CompileCache::Native.fetch(@tmp_dir, '123', Bootsnap::CompileCache::ISeq, nil)
     end
   end
 
   private
 
   def cache_key_for_file(file)
-    Bootsnap::CompileCache::Native.fetch(@tmp_dir, file, TestHandler, nil, nil)
+    Bootsnap::CompileCache::Native.fetch(@tmp_dir, file, TestHandler, nil)
     data = File.read(Help.cache_path(@tmp_dir, file))
     Help.binary(data[0..31])
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,12 @@
 # frozen_string_literal: true
 $LOAD_PATH.unshift(File.expand_path('../../lib', __FILE__))
+
+if defined? Warning
+  if Warning.respond_to?(:[]=)
+    Warning[:deprecated] = true
+  end
+end
+
 require('bundler/setup')
 require('bootsnap')
 require('bootsnap/compile_cache/yaml')
@@ -14,7 +21,7 @@ cache_dir = File.expand_path('../../tmp/bootsnap/compile-cache', __FILE__)
 Bootsnap::CompileCache.setup(cache_dir: cache_dir, iseq: true, yaml: false)
 
 module TestHandler
-  def self.input_to_storage(_i, p, _a)
+  def self.input_to_storage(_i, p)
     'neato ' + p
   end
 


### PR DESCRIPTION
The extra cache key is actually not necessary. The two options we support (`symbolize_names`, `freeze`) can be replicated by MessagePack. So if we generate the cache without options, we can keep a single cache.

However `Marshal.load` doesn't have either `symbolize_names:` nor `freeze:`. I checked bit across our apps, the fallback was only used because of a few types: `Time`, `Date`, `Regexp`. I think by just adding these types we should cover most use cases rendering the Marshal fallback useless.