### PR TITLE
Canonicalize $BUNDLE_PATH in cache keys

### DIFF
--- a/lib/bootsnap/bundler.rb
+++ b/lib/bootsnap/bundler.rb
@@ -12,4 +12,10 @@ module Bootsnap
 
     false
   end
+
+  BUNDLE_PATH = if bundler?
+    -(Bundler.bundle_path.cleanpath.to_s << '/')
+  else
+    nil
+  end
 end

--- a/lib/bootsnap/load_path_cache/path_scanner.rb
+++ b/lib/bootsnap/load_path_cache/path_scanner.rb
@@ -9,12 +9,6 @@ module Bootsnap
       NORMALIZE_NATIVE_EXTENSIONS = !DL_EXTENSIONS.include?(LoadPathCache::DOT_SO)
       ALTERNATIVE_NATIVE_EXTENSIONS_PATTERN = /\.(o|bundle|dylib)\z/
 
-      BUNDLE_PATH = if Bootsnap.bundler?
-        (Bundler.bundle_path.cleanpath.to_s << LoadPathCache::SLASH).freeze
-      else
-        ''
-      end
-
       class << self
         def call(path)
           path = File.expand_path(path.to_s).freeze
@@ -27,7 +21,7 @@ module Bootsnap
           #
           # This can happen if, for example, the user adds '.' to the load path,
           # and the bundle path is '.bundle'.
-          contains_bundle_path = BUNDLE_PATH.start_with?(path)
+          contains_bundle_path = BUNDLE_PATH&.start_with?(path)
 
           dirs = []
           requirables = []


### PR DESCRIPTION
Ref: https://github.com/heroku/heroku-buildpack-ruby/issues/979

Heroku buildpacks build the application in one location
and then move it elsewhere. This cause all the paths to change,
hence all bootsnap cache keys to be invalidated.

By replacing $BUNDLE_PATH by a constant string in the cache keys,
we allow the bundler directory to be moved without flushing the cache.

Ideally we'd use a similar substitution for the "app root", but
I need to put more thoughts into it, as I'm not too sure how
best to infer it.

cc @schneems: If you have time to give this branch a try.