### PR TITLE
Fix windows build

### DIFF
--- a/ext/bootsnap/bootsnap.c
+++ b/ext/bootsnap/bootsnap.c
@@ -311,7 +311,7 @@ bs_cache_path(const char * cachedir, const VALUE path, char (* cache_path)[MAX_C
   uint8_t first_byte = (hash >> (64 - 8));
   uint64_t remainder = hash & 0x00ffffffffffffff;
 
-  sprintf(*cache_path, "%s/%02x/%014llx", cachedir, first_byte, remainder);
+  sprintf(*cache_path, "%s/%02"PRIx8"/%014"PRIx64, cachedir, first_byte, remainder);
 }
 
 /*

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -60,17 +60,13 @@ module MiniTest
   class Test
     module Help
       class << self
-        def binary(str)
-          str.force_encoding(Encoding::BINARY)
-        end
-
         def cache_path(dir, file, args_key = nil)
           hash = fnv1a_64(file)
           unless args_key.nil?
             hash ^= fnv1a_64(args_key)
           end
 
-          hex = hash.to_s(16)
+          hex = hash.to_s(16).rjust(16, '0')
           "#{dir}/#{hex[0..1]}/#{hex[2..-1]}"
         end
 


### PR DESCRIPTION
Windows builds started failing. Turns out it's an old bug in the test suite that only surfaced because some cache keys changed.