### PR TITLE
Fix minimum msgpack version

### DIFF
--- a/bootsnap.gemspec
+++ b/bootsnap.gemspec
@@ -44,5 +44,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("minitest", "~> 5.0")
   spec.add_development_dependency("mocha", "~> 1.2")
 
-  spec.add_runtime_dependency("msgpack", "~> 1.0")
+  spec.add_runtime_dependency("msgpack", "~> 1.3")
 end


### PR DESCRIPTION
Hi, i just found `uninitialized constant MessagePack::Timestamp` error when updating bootsnap from 1.4.5 version into current version (1.7.1). It occured when i want to enter rails console:

```
bundle exec rails c
```

Here is the full stacktraces:
```
/home/imam/.rvm/gems/ruby-2.3.0/gems/bootsnap-1.7.1/lib/bootsnap/compile_cache/yaml.rb:55:in `init!': uninitialized constant MessagePack::Timestamp (NameError)
	from /home/imam/.rvm/gems/ruby-2.3.0/gems/bootsnap-1.7.1/lib/bootsnap/compile_cache/yaml.rb:40:in `install!'
	from /home/imam/.rvm/gems/ruby-2.3.0/gems/bootsnap-1.7.1/lib/bootsnap/compile_cache.rb:20:in `setup'
	from /home/imam/.rvm/gems/ruby-2.3.0/gems/bootsnap-1.7.1/lib/bootsnap.rb:67:in `setup'
	from /home/imam/.rvm/gems/ruby-2.3.0/gems/bootsnap-1.7.1/lib/bootsnap.rb:108:in `default_setup'
	from /home/imam/.rvm/gems/ruby-2.3.0/gems/bootsnap-1.7.1/lib/bootsnap/setup.rb:4:in `<top (required)>'
```

It also occured in bootsnap 1.6.0 

```
/home/imam/.rvm/gems/ruby-2.3.0/gems/bootsnap-1.6.0/lib/bootsnap/load_path_cache/core_ext/active_support.rb:80:in `block in load_missing_constant': uninitialized constant MessagePack::Timestamp (NameError)
	from /home/imam/.rvm/gems/ruby-2.3.0/gems/bootsnap-1.6.0/lib/bootsnap/load_path_cache/core_ext/active_support.rb:9:in `without_bootsnap_cache'
	from /home/imam/.rvm/gems/ruby-2.3.0/gems/bootsnap-1.6.0/lib/bootsnap/load_path_cache/core_ext/active_support.rb:80:in `rescue in load_missing_constant'
	from /home/imam/.rvm/gems/ruby-2.3.0/gems/bootsnap-1.6.0/lib/bootsnap/load_path_cache/core_ext/active_support.rb:60:in `load_missing_constant'
	from /home/imam/.rvm/gems/ruby-2.3.0/gems/bootsnap-1.6.0/lib/bootsnap/compile_cache/yaml.rb:55:in `init!'
	from /home/imam/.rvm/gems/ruby-2.3.0/gems/bootsnap-1.6.0/lib/bootsnap/compile_cache/yaml.rb:40:in `install!'
	from /home/imam/.rvm/gems/ruby-2.3.0/gems/bootsnap-1.6.0/lib/bootsnap/compile_cache.rb:20:in `setup'
	from /home/imam/.rvm/gems/ruby-2.3.0/gems/bootsnap-1.6.0/lib/bootsnap.rb:32:in `setup'
	from /home/imam/.rvm/gems/ruby-2.3.0/gems/bootsnap-1.6.0/lib/bootsnap/setup.rb:31:in `<top (required)>'
```

I found that since 1.6.0 bootsnap use `MessagePack::Timestamp` and it just introduce in [msgpack 1.3.0](https://github.com/msgpack/msgpack-ruby/blob/master/ChangeLog#L29).

https://github.com/Shopify/bootsnap/blob/9a2f1f3708e24de6de898f995f38053172e4c2c0/lib/bootsnap/compile_cache/yaml.rb#L55

**Currently bootsnap defined minimum version of msgpack in 1.0**. So if some users have `msgpack` in their Gemfile / gemspec with < 1.3 version, it will make `uninitialized constant MessagePack::Timestamp` error when running application with boostnap > 1.6 version. In my case, we defined `msgpack ~> 1.0.2` and it won't meet the bootsnap needs in the current version.

https://github.com/Shopify/bootsnap/blob/b9c5f5d9b031240b64378da32aaee6c8c0f5f2d9/bootsnap.gemspec#L47

In my opinion it's good to make minimum version of msgpack into `1.3.0`, so users don't care about it.

Thanks.
