### PR TITLE
Ignore Read-Only Filesystems

### DIFF
--- a/lib/bootsnap/load_path_cache/store.rb
+++ b/lib/bootsnap/load_path_cache/store.rb
@@ -91,7 +91,7 @@ module Bootsnap
         FileUtils.mv(tmp, @store_path)
       rescue Errno::EEXIST
         retry
-      rescue Errno::EROFS
+      rescue SystemCallError
       end
     end
   end

--- a/lib/bootsnap/load_path_cache/store.rb
+++ b/lib/bootsnap/load_path_cache/store.rb
@@ -91,6 +91,7 @@ module Bootsnap
         FileUtils.mv(tmp, @store_path)
       rescue Errno::EEXIST
         retry
+      rescue Errno::EROFS
       end
     end
   end

--- a/test/load_path_cache/store_test.rb
+++ b/test/load_path_cache/store_test.rb
@@ -74,6 +74,12 @@ module Bootsnap
 
         store.transaction { store.set('a', 1) }
       end
+
+      def test_ignore_read_only_filesystem
+        MessagePack.expects(:dump).raises(Errno::EROFS.new("Read-only file system @ rb_sysopen"))
+        store.transaction { store.set('a', 1) }
+        refute(File.exist?(@path))
+      end
     end
   end
 end


### PR DESCRIPTION
In repose to https://github.com/Shopify/bootsnap/issues/355 where using the Load Path Cache with AWS Lambda results in small differences with the `$LOAD_PATH` and tries to dumps new data to a read-only filesystem. We can ignore this error but I thought I would outline a few questions that others might have.

<dl>
  <dt>Can you use Lambda Containers `/tmp` vs the `/var/task/tmp` directory?</dt>
  <dd>No. Building a container with a `/tmp` directory will be automatically emptied out when the container image instance is loaded by Firecracker.</dd>
  <dt>Can you copy on boot to the `/tmp` directory?</dt>
  <dd>Yes. But that would negate most performance wins. </dd>
</dl>

## Example Container/Runtime `$LOAD_PATH` Differences

Assuming `l` is the Lambda Runtime load path and `d` is the ECR image via Docker. The differences would be.

```
>> d - l
=> ["/var/lang/lib/ruby/gems/2.7.0/gems/bundler-2.2.16/lib"]
>> l - d
=> ["/var/task", "/var/runtime/lib", "/opt/ruby/lib", "/var/runtime/gems/bundler-2.2.16/lib"]
```