### PR TITLE
Ignore Read-Only Filesystems for Compile Cache

### DIFF
--- a/lib/bootsnap/compile_cache/yaml.rb
+++ b/lib/bootsnap/compile_cache/yaml.rb
@@ -123,6 +123,7 @@ module Bootsnap
           rescue Errno::EACCES
             ::Bootsnap::CompileCache.permission_error(path)
           end
+          rescue SystemCallError
         end
 
         ruby2_keywords :load_file if respond_to?(:ruby2_keywords, true)

--- a/test/compile_cache/yaml_test.rb
+++ b/test/compile_cache/yaml_test.rb
@@ -89,4 +89,11 @@ class CompileCacheYAMLTest < Minitest::Test
       FakeYaml.load_file('a.yml', fallback: true)
     end
   end
+
+  def test_ignore_read_only_filesystem
+    Help.set_file('a.yml', "---\nfoo", 100)
+    Bootsnap::CompileCache::Native.expects(:fetch).raises(Errno::EROFS.new("Read-only file system @ rb_sysopen"))
+    Bootsnap::CompileCache::YAML.install!(Bootsnap::CompileCache::YAML.cache_dir)
+    document = ::YAML.load_file('a.yml')
+  end
 end


### PR DESCRIPTION
I am using Bootsnap with AWS Lambda and previously submitted a path in  #355 for the load path cache. While testing the compile cache today I noticed the following error and stack trace. The pull request mirrors the work done in #355 but instead applies this to the YAML.load_file which has `Bootsnap::CompileCache::YAML::Patch` prepended to it.

I am not super happy with the test and would appreciate any feedback. This test feels a little white box because I know it will call `Bootsnap::CompileCache::Native.fetch` under the hood. Again, feedback welcome.

```
Errno::EROFS: Read-only file system - bs_fetch:atomic_write_cache_file:mkstemp (Most recent call first)

File /var/task/vendor/bundle/ruby/2.7.0/gems/bootsnap-1.7.3/lib/bootsnap/compile_cache/yaml.rb line 117 in fetch
File /var/task/vendor/bundle/ruby/2.7.0/gems/bootsnap-1.7.3/lib/bootsnap/compile_cache/yaml.rb line 117 in load_file
File /var/task/vendor/bundle/ruby/2.7.0/gems/i18n-1.8.9/lib/i18n/backend/base.rb line 243 in load_yml
File /var/task/vendor/bundle/ruby/2.7.0/gems/i18n-1.8.9/lib/i18n/backend/base.rb line 226 in load_file
File /var/task/vendor/bundle/ruby/2.7.0/gems/i18n-1.8.9/lib/i18n/backend/base.rb line 18 in block in load_translations
File /var/task/vendor/bundle/ruby/2.7.0/gems/i18n-1.8.9/lib/i18n/backend/base.rb line 18 in each
File /var/task/vendor/bundle/ruby/2.7.0/gems/i18n-1.8.9/lib/i18n/backend/base.rb line 18 in load_translations
File /var/task/vendor/bundle/ruby/2.7.0/gems/i18n-1.8.9/lib/i18n/backend/simple.rb line 80 in init_translations
File /var/task/vendor/bundle/ruby/2.7.0/gems/i18n-1.8.9/lib/i18n/backend/simple.rb line 50 in available_locales
File /var/task/vendor/bundle/ruby/2.7.0/gems/i18n-1.8.9/lib/i18n/config.rb line 45 in available_locales
File /var/task/vendor/bundle/ruby/2.7.0/gems/i18n-1.8.9/lib/i18n/config.rb line 51 in available_locales_set
File /var/task/vendor/bundle/ruby/2.7.0/gems/i18n-1.8.9/lib/i18n.rb line 337 in locale_available?
File /var/task/vendor/bundle/ruby/2.7.0/gems/i18n-1.8.9/lib/i18n.rb line 343 in enforce_available_locales!
File /var/task/vendor/bundle/ruby/2.7.0/gems/i18n-1.8.9/lib/i18n.rb line 199 in translate
File /var/task/vendor/bundle/ruby/2.7.0/gems/activemodel-5.0.7.2/lib/active_model/naming.rb line 189 in human
File /var/task/vendor/bundle/ruby/2.7.0/gems/activemodel-5.0.7.2/lib/active_model/errors.rb line 498 in generate_message
File /var/task/vendor/bundle/ruby/2.7.0/gems/activemodel-5.0.7.2/lib/active_model/errors.rb line 528 in normalize_message
File /var/task/vendor/bundle/ruby/2.7.0/gems/activemodel-5.0.7.2/lib/active_model/errors.rb line 331 in add
```