### PR TITLE
Add prepend and append to ChangeObserver

### DIFF
--- a/lib/bootsnap/load_path_cache/change_observer.rb
+++ b/lib/bootsnap/load_path_cache/change_observer.rb
@@ -15,11 +15,13 @@ module Bootsnap
           @lpc_observer.push_paths(self, *entries.map(&:to_s))
           super
         end
+        alias_method :append, :push
 
         def unshift(*entries)
           @lpc_observer.unshift_paths(self, *entries.map(&:to_s))
           super
         end
+        alias_method :prepend, :unshift
 
         def concat(entries)
           @lpc_observer.push_paths(self, *entries.map(&:to_s))

--- a/test/load_path_cache/change_observer_test.rb
+++ b/test/load_path_cache/change_observer_test.rb
@@ -17,18 +17,29 @@ module Bootsnap
         @observer.expects(:push_paths).with(@arr, 'b', 'c')
         @arr.push('b', 'c')
 
-        @observer.expects(:unshift_paths).with(@arr, 'd', 'e')
-        @arr.unshift('d', 'e')
+        @observer.expects(:push_paths).with(@arr, 'd', 'e')
+        @arr.append('d', 'e')
 
-        @observer.expects(:push_paths).with(@arr, 'f', 'g')
-        @arr.concat(%w(f g))
+        @observer.expects(:unshift_paths).with(@arr, 'f', 'g')
+        @arr.unshift('f', 'g')
+
+        @observer.expects(:push_paths).with(@arr, 'h', 'i')
+        @arr.concat(%w(h i))
+
+        @observer.expects(:unshift_paths).with(@arr, 'j', 'k')
+        @arr.prepend('j', 'k')
+      end
+
+      def test_reinitializes_on_aggressive_modifications
+        @observer.expects(:push_paths).with(@arr, 'a', 'b', 'c')
+        @arr.push('a', 'b', 'c')
 
         @observer.expects(:reinitialize).times(4)
         @arr.delete(3)
         @arr.compact!
         @arr.map!(&:upcase)
-        assert_equal('G', @arr.pop)
-        assert_equal(%w(D E A B C F), @arr)
+        assert_equal('C', @arr.pop)
+        assert_equal(%w(A B), @arr)
       end
 
       def test_register_frozen


### PR DESCRIPTION
This PR adds `prepend` and `append` to `ChangeObserver` to make bootsnap compatible with code that uses those methods to modify the `$LOAD_PATH`.