### PR TITLE
Set encoding for write pipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Fix `Encoding::UndefinedConversionError` error for Rails applications when precompiling cache. (#364)
+
 # 1.7.5
 
 * Handle a regression of Ruby 2.7.3 causing Bootsnap to call the deprecated `untaint` method. (#360)

--- a/lib/bootsnap/cli/worker_pool.rb
+++ b/lib/bootsnap/cli/worker_pool.rb
@@ -37,7 +37,11 @@ module Bootsnap
 
         def initialize(jobs)
           @jobs = jobs
-          @pipe_out, @to_io = IO.pipe
+          @pipe_out, @to_io = IO.pipe(binmode: true)
+          # Set the writer encoding to binary since IO.pipe only sets it for the reader.
+          # https://github.com/rails/rails/issues/16514#issuecomment-52313290
+          @to_io.set_encoding(Encoding::BINARY)
+
           @pid = nil
         end
 


### PR DESCRIPTION
This fixes the `Encoding::UndefinedConversionError` error for Rails applications. Rails sets the default encoding to UTF8: https://github.com/rails/rails/blob/main/railties/lib/rails.rb#L22-L23

We want to set it to Binary but the IO.pipe method only sets it for the reader, not the writer.

This fixes https://github.com/Shopify/bootsnap/issues/243.