### PR TITLE
Fix Psych 4 compatibility and add caching for YAML.unsafe_load_file

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,23 @@ jobs:
       - run: bundle install
       - run: bundle exec rake
 
+  psych4:
+    strategy:
+      matrix:
+        os: [ubuntu]
+        ruby: ['3.0']
+    runs-on: ${{ matrix.os }}-latest
+    env:
+      PSYCH_4: "1"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - run: bundle install
+      - run: bundle exec rake
+    
+
   minimal:
     strategy:
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Improve support for Pysch 4.
+
 # 1.7.7
 
 * Fix `require_relative` in evaled code on latest ruby 3.1.0-dev. (#366)

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,10 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in bootsnap.gemspec
 gemspec
 
+if ENV["PSYCH_4"]
+  gem "psych", ">= 4"
+end
+
 group :development do
   gem 'rubocop'
   gem 'byebug', platform: :ruby

--- a/test/compile_cache/yaml_test.rb
+++ b/test/compile_cache/yaml_test.rb
@@ -6,17 +6,21 @@ class CompileCacheYAMLTest < Minitest::Test
 
   module FakeYaml
     Fallback = Class.new(StandardError)
-    extend self
-    singleton_class.prepend(Bootsnap::CompileCache::YAML::Patch)
+    class << self
+      def load_file(path, symbolize_names: false, freeze: false, fallback: nil)
+        raise Fallback
+      end
 
-    def load_file(path, symbolize_names: false, freeze: false, fallback: nil)
-      raise Fallback
+      def unsafe_load_file(path, symbolize_names: false, freeze: false, fallback: nil)
+        raise Fallback
+      end
     end
   end
 
   def setup
     super
     Bootsnap::CompileCache::YAML.init!
+    FakeYaml.singleton_class.prepend(Bootsnap::CompileCache::YAML::Patch)
   end
 
   def test_yaml_strict_load
@@ -44,49 +48,72 @@ class CompileCacheYAMLTest < Minitest::Test
     assert_equal "YAML tags are not supported: !ruby/object", error.message
   end
 
-  def test_load_file
-    Help.set_file('a.yml', "---\nfoo: bar", 100)
-    assert_equal({'foo' => 'bar'}, FakeYaml.load_file('a.yml'))
-  end
-
-  def test_load_file_symbolize_names
-    Help.set_file('a.yml', "---\nfoo: bar", 100)
-    FakeYaml.load_file('a.yml')
-
-    if ::Bootsnap::CompileCache::YAML.supported_options.include?(:symbolize_names)
-      2.times do
-        assert_equal({foo: 'bar'}, FakeYaml.load_file('a.yml', symbolize_names: true))
+  if YAML::VERSION >= '4'
+    def test_load_psych_4
+      # Until we figure out a proper strategy, only `YAML.unsafe_load_file`
+      # is cached with Psych >= 4
+      Help.set_file('a.yml', "foo: &foo\n  bar: 42\nplop:\n  <<: *foo", 100)
+      assert_raises FakeYaml::Fallback do
+        FakeYaml.load_file('a.yml')
       end
-    else
+    end
+  else
+    def test_load_file
+      Help.set_file('a.yml', "---\nfoo: bar", 100)
+      assert_equal({'foo' => 'bar'}, FakeYaml.load_file('a.yml'))
+    end
+
+    def test_load_file_aliases
+      Help.set_file('a.yml', "foo: &foo\n  bar: 42\nplop:\n  <<: *foo", 100)
+      assert_equal({"foo" => { "bar" => 42 }, "plop" => { "bar" => 42} }, FakeYaml.load_file('a.yml'))
+    end
+
+    def test_load_file_symbolize_names
+      Help.set_file('a.yml', "---\nfoo: bar", 100)
+      FakeYaml.load_file('a.yml')
+
+      if ::Bootsnap::CompileCache::YAML.supported_options.include?(:symbolize_names)
+        2.times do
+          assert_equal({foo: 'bar'}, FakeYaml.load_file('a.yml', symbolize_names: true))
+        end
+      else
+        assert_raises(FakeYaml::Fallback) do # would call super
+          FakeYaml.load_file('a.yml', symbolize_names: true)
+        end
+      end
+    end
+
+    def test_load_file_freeze
+      Help.set_file('a.yml', "---\nfoo", 100)
+      FakeYaml.load_file('a.yml')
+
+      if ::Bootsnap::CompileCache::YAML.supported_options.include?(:freeze)
+        2.times do
+          string = FakeYaml.load_file('a.yml', freeze: true)
+          assert_equal("foo", string)
+          assert_predicate(string, :frozen?)
+        end
+      else
+        assert_raises(FakeYaml::Fallback) do # would call super
+          FakeYaml.load_file('a.yml', freeze: true)
+        end
+      end
+    end
+
+    def test_load_file_unknown_option
+      Help.set_file('a.yml', "---\nfoo", 100)
+      FakeYaml.load_file('a.yml')
+
       assert_raises(FakeYaml::Fallback) do # would call super
-        FakeYaml.load_file('a.yml', symbolize_names: true)
+        FakeYaml.load_file('a.yml', fallback: true)
       end
     end
   end
 
-  def test_load_file_freeze
-    Help.set_file('a.yml', "---\nfoo", 100)
-    FakeYaml.load_file('a.yml')
-
-    if ::Bootsnap::CompileCache::YAML.supported_options.include?(:freeze)
-      2.times do
-        string = FakeYaml.load_file('a.yml', freeze: true)
-        assert_equal("foo", string)
-        assert_predicate(string, :frozen?)
-      end
-    else
-      assert_raises(FakeYaml::Fallback) do # would call super
-        FakeYaml.load_file('a.yml', freeze: true)
-      end
-    end
-  end
-
-  def test_load_file_unknown_option
-    Help.set_file('a.yml', "---\nfoo", 100)
-    FakeYaml.load_file('a.yml')
-
-    assert_raises(FakeYaml::Fallback) do # would call super
-      FakeYaml.load_file('a.yml', fallback: true)
+  if YAML.respond_to?(:unsafe_load_file)
+    def test_unsafe_load_file
+      Help.set_file('a.yml', "foo: &foo\n  bar: 42\nplop:\n  <<: *foo", 100)
+      assert_equal({"foo" => { "bar" => 42 }, "plop" => { "bar" => 42} }, FakeYaml.unsafe_load_file('a.yml'))
     end
   end
 end


### PR DESCRIPTION
Psych 4 now load in safe mode by default, which means many
features such as aliases are disabled by default.

This makes it complicated for Bootsnap to cache, and pretty
much impossible to precompile.

So until we figure out a better solution, we're better to
entirely disable that cache for Psych 4+. However it
can stay active for `YAML.unsafe_load_file`.