### PR TITLE
psych < 4 fix

### DIFF
--- a/lib/bootsnap/compile_cache/yaml.rb
+++ b/lib/bootsnap/compile_cache/yaml.rb
@@ -23,7 +23,11 @@ module Bootsnap
         end
 
         def input_to_output(data, kwargs)
-          ::YAML.unsafe_load(data, **(kwargs || {}))
+          if ::YAML.respond_to?(:unsafe_load)
+            ::YAML.unsafe_load(data, **(kwargs || {}))
+          else
+            ::YAML.load(data, **(kwargs || {}))
+          end
         end
 
         def strict_load(payload, *args)

--- a/test/compile_cache/yaml_test.rb
+++ b/test/compile_cache/yaml_test.rb
@@ -36,6 +36,19 @@ class CompileCacheYAMLTest < Minitest::Test
     assert_equal expected, document
   end
 
+  def test_yaml_input_to_output
+    document = ::Bootsnap::CompileCache::YAML.input_to_output(<<~YAML, {})
+      ---
+      :foo: 42
+      bar: [1]
+    YAML
+    expected = {
+      foo: 42,
+      'bar' => [1],
+    }
+    assert_equal expected, document
+  end
+
   def test_yaml_tags
     error = assert_raises Bootsnap::CompileCache::Uncompilable do
       ::Bootsnap::CompileCache::YAML.strict_load('!many Boolean')


### PR DESCRIPTION
`unsafe_load` doesn't exist on older versions https://github.com/Shopify/bootsnap/pull/368

fixes
```
Failure/Error: ::YAML.unsafe_load(data, **(kwargs || {}))
NoMethodError:
  undefined method `unsafe_load' for Psych:Module
  Did you mean?  safe_load
# /usr/local/rvm/gems/ruby-2.6.6-railsexpress/gems/bootsnap-1.8.0/lib/bootsnap/compile_cache/yaml.rb:26:in `input_to_output'
# /usr/local/rvm/gems/ruby-2.6.6-railsexpress/gems/bootsnap-1.8.0/lib/bootsnap/compile_cache/yaml.rb:124:in `fetch'
# /usr/local/rvm/gems/ruby-2.6.6-railsexpress/gems/bootsnap-1.8.0/lib/bootsnap/compile_cache/yaml.rb:124:in `load_file'
```