### PR TITLE
Implement a JSON compilation cache

### DIFF
--- a/lib/bootsnap.rb
+++ b/lib/bootsnap.rb
@@ -43,7 +43,8 @@ module Bootsnap
     autoload_paths_cache: nil,
     disable_trace: nil,
     compile_cache_iseq: true,
-    compile_cache_yaml: true
+    compile_cache_yaml: true,
+    compile_cache_json: true
   )
     unless autoload_paths_cache.nil?
       warn "[DEPRECATED] Bootsnap's `autoload_paths_cache:` option is deprecated and will be removed. " \
@@ -69,7 +70,8 @@ module Bootsnap
     Bootsnap::CompileCache.setup(
       cache_dir: cache_dir + '/bootsnap/compile-cache',
       iseq: compile_cache_iseq,
-      yaml: compile_cache_yaml
+      yaml: compile_cache_yaml,
+      json: compile_cache_json,
     )
   end
 
@@ -113,6 +115,7 @@ module Bootsnap
         load_path_cache:      !ENV['DISABLE_BOOTSNAP_LOAD_PATH_CACHE'],
         compile_cache_iseq:   !ENV['DISABLE_BOOTSNAP_COMPILE_CACHE'] && iseq_cache_supported?,
         compile_cache_yaml:   !ENV['DISABLE_BOOTSNAP_COMPILE_CACHE'],
+        compile_cache_json:   !ENV['DISABLE_BOOTSNAP_COMPILE_CACHE'],
       )
 
       if ENV['BOOTSNAP_LOG']

--- a/lib/bootsnap/compile_cache.rb
+++ b/lib/bootsnap/compile_cache.rb
@@ -4,7 +4,7 @@ module Bootsnap
     Error           = Class.new(StandardError)
     PermissionError = Class.new(Error)
 
-    def self.setup(cache_dir:, iseq:, yaml:)
+    def self.setup(cache_dir:, iseq:, yaml:, json:)
       if iseq
         if supported?
           require_relative('compile_cache/iseq')
@@ -18,6 +18,15 @@ module Bootsnap
         if supported?
           require_relative('compile_cache/yaml')
           Bootsnap::CompileCache::YAML.install!(cache_dir)
+        elsif $VERBOSE
+          warn("[bootsnap/setup] YAML parsing caching is not supported on this implementation of Ruby")
+        end
+      end
+
+      if json
+        if supported?
+          require_relative('compile_cache/json')
+          Bootsnap::CompileCache::JSON.install!(cache_dir)
         elsif $VERBOSE
           warn("[bootsnap/setup] YAML parsing caching is not supported on this implementation of Ruby")
         end

--- a/lib/bootsnap/compile_cache/json.rb
+++ b/lib/bootsnap/compile_cache/json.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+require('bootsnap/bootsnap')
+
+module Bootsnap
+  module CompileCache
+    module JSON
+      class << self
+        attr_accessor(:msgpack_factory, :cache_dir, :supported_options)
+
+        def input_to_storage(payload, _)
+          obj = ::JSON.parse(payload)
+          msgpack_factory.dump(obj)
+        end
+
+        def storage_to_output(data, kwargs)
+          if kwargs && kwargs.key?(:symbolize_names)
+            kwargs[:symbolize_keys] = kwargs.delete(:symbolize_names)
+          end
+          msgpack_factory.load(data, kwargs)
+        end
+
+        def input_to_output(data, kwargs)
+          ::JSON.parse(data, **(kwargs || {}))
+        end
+
+        def precompile(path, cache_dir: self.cache_dir)
+          Bootsnap::CompileCache::Native.precompile(
+            cache_dir,
+            path.to_s,
+            self,
+          )
+        end
+
+        def install!(cache_dir)
+          self.cache_dir = cache_dir
+          init!
+          if ::JSON.respond_to?(:load_file)
+            ::JSON.singleton_class.prepend(Patch)
+          end
+        end
+
+        def init!
+          require('json')
+          require('msgpack')
+
+          self.msgpack_factory = MessagePack::Factory.new
+          self.supported_options = [:symbolize_names]
+          if ::JSON.parse('["foo"]', freeze: true).first.frozen?
+            self.supported_options = [:freeze]
+          end
+          self.supported_options.freeze
+        end
+      end
+
+      module Patch
+        def load_file(path, *args)
+          return super if args.size > 1
+          if kwargs = args.first
+            return super unless kwargs.is_a?(Hash)
+            return super unless (kwargs.keys - ::Bootsnap::CompileCache::JSON.supported_options).empty?
+          end
+
+          begin
+            ::Bootsnap::CompileCache::Native.fetch(
+              Bootsnap::CompileCache::JSON.cache_dir,
+              File.realpath(path),
+              ::Bootsnap::CompileCache::JSON,
+              kwargs,
+            )
+          rescue Errno::EACCES
+            ::Bootsnap::CompileCache.permission_error(path)
+          end
+        end
+
+        ruby2_keywords :load_file if respond_to?(:ruby2_keywords, true)
+      end
+    end
+  end
+end

--- a/test/compile_cache/json_test.rb
+++ b/test/compile_cache/json_test.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+require('test_helper')
+
+class CompileCacheJSONTest < Minitest::Test
+  include(TmpdirHelper)
+
+  module FakeJson
+    Fallback = Class.new(StandardError)
+    class << self
+      def load_file(path, symbolize_names: false, freeze: false, fallback: nil)
+        raise Fallback
+      end
+    end
+  end
+
+  def setup
+    super
+    Bootsnap::CompileCache::JSON.init!
+    FakeJson.singleton_class.prepend(Bootsnap::CompileCache::JSON::Patch)
+  end
+
+  def test_json_input_to_output
+    document = ::Bootsnap::CompileCache::JSON.input_to_output(<<~JSON, {})
+      {
+        "foo": 42,
+        "bar": [1]
+      }
+    JSON
+    expected = {
+      'foo' => 42,
+      'bar' => [1],
+    }
+    assert_equal expected, document
+  end
+
+  def test_load_file
+    Help.set_file('a.json', '{"foo": "bar"}', 100)
+    assert_equal({'foo' => 'bar'}, FakeJson.load_file('a.json'))
+  end
+
+  def test_load_file_symbolize_names
+    Help.set_file('a.json', '{"foo": "bar"}', 100)
+    FakeJson.load_file('a.json')
+
+    if ::Bootsnap::CompileCache::JSON.supported_options.include?(:symbolize_names)
+      2.times do
+        assert_equal({foo: 'bar'}, FakeJson.load_file('a.json', symbolize_names: true))
+      end
+    else
+      assert_raises(FakeJson::Fallback) do # would call super
+        FakeJson.load_file('a.json', symbolize_names: true)
+      end
+    end
+  end
+
+  def test_load_file_freeze
+    Help.set_file('a.json', '["foo"]', 100)
+    FakeJson.load_file('a.json')
+
+    if ::Bootsnap::CompileCache::JSON.supported_options.include?(:freeze)
+      2.times do
+        string = FakeJson.load_file('a.json', freeze: true).first
+        assert_equal("foo", string)
+        assert_predicate(string, :frozen?)
+      end
+    else
+      assert_raises(FakeJson::Fallback) do # would call super
+        FakeJson.load_file('a.json', freeze: true)
+      end
+    end
+  end
+
+  def test_load_file_unknown_option
+    Help.set_file('a.json', '["foo"]', 100)
+    FakeJson.load_file('a.json')
+
+    assert_raises(FakeJson::Fallback) do # would call super
+      FakeJson.load_file('a.json', fallback: true)
+    end
+  end
+end

--- a/test/setup_test.rb
+++ b/test/setup_test.rb
@@ -20,6 +20,7 @@ module Bootsnap
         load_path_cache: true,
         compile_cache_iseq: Bootsnap.iseq_cache_supported?,
         compile_cache_yaml: true,
+        compile_cache_json: true,
       )
 
       Bootsnap.default_setup
@@ -34,6 +35,7 @@ module Bootsnap
         load_path_cache: true,
         compile_cache_iseq: Bootsnap.iseq_cache_supported?,
         compile_cache_yaml: true,
+        compile_cache_json: true,
       )
 
       Bootsnap.default_setup
@@ -48,6 +50,7 @@ module Bootsnap
         load_path_cache: false,
         compile_cache_iseq: Bootsnap.iseq_cache_supported?,
         compile_cache_yaml: true,
+        compile_cache_json: true,
       )
 
       Bootsnap.default_setup
@@ -62,6 +65,7 @@ module Bootsnap
         load_path_cache: true,
         compile_cache_iseq: false,
         compile_cache_yaml: false,
+        compile_cache_json: false,
       )
 
       Bootsnap.default_setup
@@ -83,6 +87,7 @@ module Bootsnap
         load_path_cache: true,
         compile_cache_iseq: Bootsnap.iseq_cache_supported?,
         compile_cache_yaml: true,
+        compile_cache_json: true,
       )
       Bootsnap.expects(:logger=).with($stderr.method(:puts))
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,6 +10,7 @@ end
 require('bundler/setup')
 require('bootsnap')
 require('bootsnap/compile_cache/yaml')
+require('bootsnap/compile_cache/json')
 
 require('tmpdir')
 require('fileutils')
@@ -18,7 +19,7 @@ require('minitest/autorun')
 require('mocha/minitest')
 
 cache_dir = File.expand_path('../../tmp/bootsnap/compile-cache', __FILE__)
-Bootsnap::CompileCache.setup(cache_dir: cache_dir, iseq: true, yaml: false)
+Bootsnap::CompileCache.setup(cache_dir: cache_dir, iseq: true, yaml: false, json: false)
 
 if GC.respond_to?(:verify_compaction_references)
   # This method was added in Ruby 3.0.0. Calling it this way asks the GC to
@@ -99,6 +100,7 @@ module TmpdirHelper
     @prev = Bootsnap::CompileCache::ISeq.cache_dir
     Bootsnap::CompileCache::ISeq.cache_dir = @tmp_dir
     Bootsnap::CompileCache::YAML.cache_dir = @tmp_dir
+    Bootsnap::CompileCache::JSON.cache_dir = @tmp_dir
   end
 
   def teardown
@@ -107,5 +109,6 @@ module TmpdirHelper
     FileUtils.remove_entry(@tmp_dir)
     Bootsnap::CompileCache::ISeq.cache_dir = @prev
     Bootsnap::CompileCache::YAML.cache_dir = @prev
+    Bootsnap::CompileCache::JSON.cache_dir = @prev
   end
 end


### PR DESCRIPTION
Now that the `json` gem added a `JSON.load_file` method, we can apply the same optimization than for YAML.