### PR TITLE
Fixup `Kernel.load`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Fix `Kernel.load` behavior: before `load 'a'` would load `a.rb` (and other tried extensions) and wouldn't load `a` unless `development_mode: true`, now only `a` would be loaded and files with extensions wouldn't be.
+
 # 1.9.1
 
 * Removed a forgotten debug statement in JSON precompilation.

--- a/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb
+++ b/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb
@@ -56,27 +56,9 @@ module Kernel
 
   alias_method(:load_without_bootsnap, :load)
   def load(path, wrap = false)
-    if (resolved = Bootsnap::LoadPathCache.load_path_cache.find(path))
-      return load_without_bootsnap(resolved, wrap)
-    end
+    resolved = Bootsnap::LoadPathCache.load_path_cache.find(path, try_extensions: false)
 
-    # load also allows relative paths from pwd even when not in $:
-    if File.exist?(relative = File.expand_path(path).freeze)
-      return load_without_bootsnap(relative, wrap)
-    end
-
-    raise(Bootsnap::LoadPathCache::CoreExt.make_load_error(path))
-  rescue LoadError => e
-    e.instance_variable_set(Bootsnap::LoadPathCache::ERROR_TAG_IVAR, true)
-    raise(e)
-  rescue Bootsnap::LoadPathCache::ReturnFalse
-    false
-  rescue Bootsnap::LoadPathCache::FallbackScan
-    fallback = true
-  ensure
-    if fallback
-      load_without_bootsnap(path, wrap)
-    end
+    resolved ? load_without_bootsnap(resolved, wrap) : load_without_bootsnap(path, wrap)
   end
 end
 

--- a/test/load_path_cache/cache_test.rb
+++ b/test/load_path_cache/cache_test.rb
@@ -49,8 +49,10 @@ module Bootsnap
         po = [@dir1]
         cache = Cache.new(NullCache, po)
         assert_equal("#{@dir1}/a.rb", cache.find('a'))
+        refute(cache.find('a', try_extensions: false))
         cache.push_paths(po, @dir2)
         assert_equal("#{@dir2}/b.rb", cache.find('b'))
+        refute(cache.find('b', try_extensions: false))
       end
 
       def test_extension_append_for_relative_paths
@@ -58,8 +60,11 @@ module Bootsnap
         cache = Cache.new(NullCache, po)
         Dir.chdir(@dir1) do
           assert_equal("#{@dir1}/a.rb",       cache.find('./a'))
+          assert_equal("#{@dir1}/a",          cache.find('./a', try_extensions: false))
           assert_equal("#{@dir1}/dl#{DLEXT}", cache.find('./dl'))
+          assert_equal("#{@dir1}/dl",         cache.find('./dl', try_extensions: false))
           assert_equal("#{@dir1}/enoent",     cache.find('./enoent'))
+          assert_equal("#{@dir1}/enoent",     cache.find('./enoent', try_extensions: false))
         end
       end
 
@@ -67,16 +72,20 @@ module Bootsnap
         po = [@dir1]
         cache = Cache.new(NullCache, po)
         assert_equal("#{@dir1}/conflict.rb", cache.find('conflict'))
+        assert_equal("#{@dir1}/conflict.rb", cache.find('conflict.rb', try_extensions: false))
         cache.unshift_paths(po, @dir2)
         assert_equal("#{@dir2}/conflict.rb", cache.find('conflict'))
+        assert_equal("#{@dir2}/conflict.rb", cache.find('conflict.rb', try_extensions: false))
       end
 
       def test_pushed_paths_have_lower_precedence
         po = [@dir1]
         cache = Cache.new(NullCache, po)
         assert_equal("#{@dir1}/conflict.rb", cache.find('conflict'))
+        assert_equal("#{@dir1}/conflict.rb", cache.find('conflict.rb', try_extensions: false))
         cache.push_paths(po, @dir2)
         assert_equal("#{@dir1}/conflict.rb", cache.find('conflict'))
+        assert_equal("#{@dir1}/conflict.rb", cache.find('conflict.rb', try_extensions: false))
       end
 
       def test_directory_caching
@@ -89,10 +98,14 @@ module Bootsnap
       def test_extension_permutations
         cache = Cache.new(NullCache, [@dir1])
         assert_equal("#{@dir1}/dl#{DLEXT}", cache.find('dl'))
+        refute(cache.find('dl', try_extensions: false))
         assert_equal("#{@dir1}/dl#{DLEXT}", cache.find("dl#{DLEXT}"))
         assert_equal("#{@dir1}/both.rb", cache.find("both"))
+        refute(cache.find("both", try_extensions: false))
         assert_equal("#{@dir1}/both.rb", cache.find("both.rb"))
+        assert_equal("#{@dir1}/both.rb", cache.find("both.rb", try_extensions: false))
         assert_equal("#{@dir1}/both#{DLEXT}", cache.find("both#{DLEXT}"))
+        assert_equal("#{@dir1}/both#{DLEXT}", cache.find("both#{DLEXT}", try_extensions: false))
       end
 
       def test_relative_paths_rescanned

--- a/test/load_path_cache/core_ext/kernel_require_test.rb
+++ b/test/load_path_cache/core_ext/kernel_require_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+require('test_helper')
+
+module Bootsnap
+  module KernelRequireTest
+    class KernelLoadTest < MiniTest::Test
+      def setup
+        @initial_dir = Dir.pwd
+        @dir1 = File.realpath(Dir.mktmpdir)
+        FileUtils.touch("#{@dir1}/a.rb")
+        FileUtils.touch("#{@dir1}/no_ext")
+        @dir2 = File.realpath(Dir.mktmpdir)
+        File.open("#{@dir2}/loads.rb", "wb") { |f| f.write("load 'subdir/loaded'\nload './subdir/loaded'\n") }
+        FileUtils.mkdir("#{@dir2}/subdir")
+        FileUtils.touch("#{@dir2}/subdir/loaded")
+        $LOAD_PATH.push(@dir1)
+      end
+
+      def teardown
+        $LOAD_PATH.pop
+        Dir.chdir(@initial_dir)
+        FileUtils.rm_rf(@dir1)
+        FileUtils.rm_rf(@dir2)
+      end
+
+      def test_no_exstensions_for_kernel_load
+        assert_raises(LoadError) { load 'a' }
+        assert(load 'no_ext')
+        Dir.chdir(@dir2)
+        assert(load 'loads.rb')
+      end
+    end
+  end
+end


### PR DESCRIPTION
It requires exact filename and doen't try any extensions, so currently
bootsnap implementation has two issues:
1. `load 'a'` will load `a.rb`
2. `load 'a'` will not load `a` unless `development_mode: true` and
fallback scan is activated

We can add this records to the cache, but probably it's too obscure
to justify more complex code and will not lead to improved
performance.

We can add all files to the store in `PathScanner#call`, but AFAIU
there is extension check there to skip probably non-requireable file
for performance reasons