### PR TITLE
Only disable the compile cache for source files impacted by Ruby 3.0.3 [Bug #18250]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+* Only disable the compile cache for source files impacted by [Ruby 3.0.3 [Bug 18250]](https://bugs.ruby-lang.org/issues/18250).
+  This should keep the performance loss to a minimum.
+
 # 1.9.2
 
 * Disable compile cache if Ruby 3.0.3's ISeq cache bug is detected.

--- a/lib/bootsnap.rb
+++ b/lib/bootsnap.rb
@@ -57,15 +57,9 @@ module Bootsnap
         "If you use Ruby 2.5 or newer this option is useless, if not upgrading is recommended."
     end
 
-    if compile_cache_iseq
-      if iseq_cache_tracing_bug?
-        warn "Ruby 2.5 has a bug that break code tracing when code is loaded from cache. It is recommended " \
-          "to turn `compile_cache_iseq` off on Ruby 2.5"
-      end
-
-      if iseq_cache_anonymous_params_bug?
-        warn "Your version of Ruby 3.1.0-dev has a bug that break bytecode caching (https://github.com/ruby/ruby/pull/4961)."
-      end
+    if compile_cache_iseq && !iseq_cache_supported?
+      warn "Ruby 2.5 has a bug that break code tracing when code is loaded from cache. It is recommened " \
+        "to turn `compile_cache_iseq` off on Ruby 2.5"
     end
 
     Bootsnap::LoadPathCache.setup(
@@ -81,28 +75,11 @@ module Bootsnap
     )
   end
 
-  def self.iseq_cache_tracing_bug?
-    return @iseq_cache_tracing_bug if defined? @iseq_cache_tracing_bug
+  def self.iseq_cache_supported?
+    return @iseq_cache_supported if defined? @iseq_cache_supported
 
     ruby_version = Gem::Version.new(RUBY_VERSION)
-    @iseq_cache_tracing_bug = ruby_version < Gem::Version.new('2.5.0') || ruby_version >= Gem::Version.new('2.6.0')
-  end
-
-  def self.iseq_cache_anonymous_params_bug?
-    return @iseq_cache_anonymous_params_bug if defined? @iseq_cache_anonymous_params_bug
-    begin
-      if defined? RubyVM::InstructionSequence
-        RubyVM::InstructionSequence.compile("def foo(*); ->{ super }; end").to_binary
-        RubyVM::InstructionSequence.compile("def foo(**); ->{ super }; end").to_binary
-      end
-      false
-    rescue TypeError
-      true
-    end
-  end
-
-  def self.iseq_cache_supported?
-    !(iseq_cache_tracing_bug? || iseq_cache_anonymous_params_bug?)
+    @iseq_cache_supported = ruby_version < Gem::Version.new('2.5.0') || ruby_version >= Gem::Version.new('2.6.0')
   end
 
   def self.default_setup

--- a/test/compile_cache/iseq_cache_test.rb
+++ b/test/compile_cache/iseq_cache_test.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+require('test_helper')
+
+class CompileCacheISeqTest < Minitest::Test
+  include(TmpdirHelper)
+
+  def test_ruby_bug_18250
+    Help.set_file('a.rb', 'def foo(*); ->{ super }; end; def foo(**); ->{ super }; end', 100)
+    Bootsnap::CompileCache::ISeq.fetch('a.rb')
+  end
+end


### PR DESCRIPTION
I'm just kinda worried some source files may not explicitly break, but might load some corrupted iseqs instead.

I'll run this branch against our CI to make sure. 