### PR TITLE
Update minimum version of msgpack

### DIFF
--- a/bootsnap.gemspec
+++ b/bootsnap.gemspec
@@ -44,5 +44,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("minitest", "~> 5.0")
   spec.add_development_dependency("mocha", "~> 1.2")
 
-  spec.add_runtime_dependency("msgpack", "~> 1.0")
+  spec.add_runtime_dependency("msgpack", "~> 1.4")
 end


### PR DESCRIPTION
With msgpack 1.1 tests fail with NoMethodError: undefined method `dump' for #<MessagePack::Factory:0x000055abe3562c70>