### PR TITLE
LoadedFeaturesIndex#register: Ignore absolute paths entirely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+* Ignore absolute paths in the loaded feature index. (#385)
+  This fixes a compatibility issue with Zeitwerk when Zeitwerk is loaded before bootsnap. It also should
+  reduce the memory usage and improve load performance of Zeitwerk managed files.
+
 * Automatically invalidate the load path cache whenever the Ruby version change. (#387)
   This is to avoid issues in case the same installation path is re-used for subsequent ruby patch releases.
 

--- a/lib/bootsnap.rb
+++ b/lib/bootsnap.rb
@@ -123,4 +123,14 @@ module Bootsnap
       end
     end
   end
+
+  if RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/
+    def self.absolute_path?(path)
+      path[1] == ':'
+    end
+  else
+    def self.absolute_path?(path)
+      path.start_with?('/')
+    end
+  end
 end

--- a/lib/bootsnap/load_path_cache/cache.rb
+++ b/lib/bootsnap/load_path_cache/cache.rb
@@ -48,7 +48,7 @@ module Bootsnap
         reinitialize if (@has_relative_paths && dir_changed?) || stale?
         feature = feature.to_s.freeze
 
-        return feature if absolute_path?(feature)
+        return feature if Bootsnap.absolute_path?(feature)
 
         if feature.start_with?('./', '../')
           return try_extensions ? expand_path(feature) : File.expand_path(feature).freeze
@@ -96,16 +96,6 @@ module Bootsnap
         # be able to detect newly-created files without rebooting the
         # application.
         raise(LoadPathCache::FallbackScan, '', []) if @development_mode
-      end
-
-      if RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/
-        def absolute_path?(path)
-          path[1] == ':'
-        end
-      else
-        def absolute_path?(path)
-          path.start_with?(SLASH)
-        end
       end
 
       def unshift_paths(sender, *paths)

--- a/lib/bootsnap/load_path_cache/loaded_features_index.rb
+++ b/lib/bootsnap/load_path_cache/loaded_features_index.rb
@@ -83,6 +83,11 @@ module Bootsnap
       # 2. Inspect $LOADED_FEATURES upon return from yield to find the matching
       #    entry.
       def register(short, long = nil)
+        # Absolute paths are not a concern.
+        if Bootsnap.absolute_path?(short.to_s)
+          return yield
+        end
+
         if long.nil?
           len = $LOADED_FEATURES.size
           ret = yield

--- a/test/load_path_cache/loaded_features_index_test.rb
+++ b/test/load_path_cache/loaded_features_index_test.rb
@@ -136,10 +136,22 @@ module Bootsnap
       end
 
       def test_works_with_pathname
-        path = '/tmp/bundler.rb'
+        path = 'bundler.rb'
         pathname = Pathname.new(path)
         @index.register(pathname, path) { true }
         assert(@index.key?(pathname))
+      end
+
+      def test_ignores_absolute_paths
+        path = "#{Dir.mktmpdir}/bundler.rb"
+        @index.register(path) { true }
+        refute(@index.key?(path))
+
+        path = "#{Dir.mktmpdir}/bundler.rb"
+        pathname = Pathname.new(path)
+        @index.register(pathname, path) { true }
+        refute(@index.key?(path))
+        refute(@index.key?(pathname))
       end
     end
   end


### PR DESCRIPTION
Fix: https://github.com/Shopify/bootsnap/issues/383
Ref: https://github.com/fxn/zeitwerk/issues/198

The loaded feature index goal is to prevent requiring the same "feature" twice if the `$LOAD_PATH` was mutated. e.g:

```ruby
require "bundler" # ~/gems/bundler/lib/bundler.rb
$LOAD_PATH.unshift("some/path")
require "bundler" # some/path/bundler.rb
```

In such scenario Ruby remember that you require "bundler" already and even though it now maps to a new path, it won't load it again.

This was causing issues with Zeitwerk if it is loaded before bootsnap (see refs), because the cache wouldn't be cleared.

But ultimately Zeitwerk always require absolute paths, and the concern described above simply doesn't apply to absolute paths. So we can simply bail out early in these cases. That fixes the bug, and also means less work and a smaller index, so win-win.

cc @fxn 