### PR TITLE
Add Bootsnap.unload_cache!

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,8 @@ jobs:
       - run: bundle exec rake
 
   rubocop:
+    strategy:
+      fail-fast: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -38,6 +40,7 @@ jobs:
 
   rubies:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu]
         ruby: ['2.5', '2.6', '2.7', '3.0', '3.1', 'ruby-head', 'debug']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
   People still using the classic autoloader might want to stick to `bootsnap 1.12`.
 
+* Add `Bootsnap.unload_cache!`. Applications can call it at the end of their boot sequence when they know
+  no more code will be loaded to reclaim a bit of memory.
+
 # 1.12.0
 
 * `bootsnap precompile` CLI will now also precompile `Rakefile` and `.rake` files.

--- a/lib/bootsnap.rb
+++ b/lib/bootsnap.rb
@@ -76,6 +76,10 @@ module Bootsnap
       )
     end
 
+    def self.unload_cache!
+      LoadPathCache.unload!
+    end
+
     def iseq_cache_supported?
       return @iseq_cache_supported if defined? @iseq_cache_supported
 

--- a/lib/bootsnap/load_path_cache/cache.rb
+++ b/lib/bootsnap/load_path_cache/cache.rb
@@ -114,7 +114,7 @@ module Bootsnap
       def reinitialize(path_obj = @path_obj)
         @mutex.synchronize do
           @path_obj = path_obj
-          ChangeObserver.register(self, @path_obj)
+          ChangeObserver.register(@path_obj, self)
           @index = {}
           @dirs = {}
           @generated_at = now

--- a/lib/bootsnap/load_path_cache/change_observer.rb
+++ b/lib/bootsnap/load_path_cache/change_observer.rb
@@ -56,11 +56,22 @@ module Bootsnap
         end
       end
 
-      def self.register(observer, arr)
+      def self.register(arr, observer)
         return if arr.frozen? # can't register observer, but no need to.
 
         arr.instance_variable_set(:@lpc_observer, observer)
-        arr.extend(ArrayMixin)
+        ArrayMixin.instance_methods.each do |method_name|
+          arr.singleton_class.send(:define_method, method_name, ArrayMixin.instance_method(method_name))
+        end
+      end
+
+      def self.unregister(arr)
+        return unless arr.instance_variable_get(:@lpc_observer)
+
+        ArrayMixin.instance_methods.each do |method_name|
+          arr.singleton_class.send(:remove_method, method_name)
+        end
+        arr.instance_variable_set(:@lpc_observer, nil)
       end
     end
   end

--- a/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb
+++ b/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb
@@ -6,6 +6,8 @@ module Kernel
   alias_method(:require_without_bootsnap, :require)
 
   def require(path)
+    return require_without_bootsnap(path) unless Bootsnap::LoadPathCache.enabled?
+
     string_path = Bootsnap.rb_get_path(path)
     return false if Bootsnap::LoadPathCache.loaded_features_index.key?(string_path)
 


### PR DESCRIPTION
Fix: https://github.com/Shopify/bootsnap/issues/386

I tested it on our monolith, seem to work and frees about 7.4MB of memory (it's really a big app, so it would be much less for the average user).

Not quite sure what's the best way to integrate it is just yet. Right now I've put:

```ruby
# config/application.rb
    config.after_initialize do
      if config.eager_load
        puts "[Bootsnap] unload cache"
        Bootsnap.unload_cache!
      end
    end
```

But it might make sense to only do this in `config/environments/production.rb`, because we do have eagerloading on CI and this would trigger before the tests and `test_helper.rb` are loaded, so it won't be able to help loading test dependencies. Also Memory usage is generally much less critical on CI.

As said on the issue it would be nice to make this happen automatically with a Rails of some sort, but it might be tricky given how early bootsnap is loaded. Maybe through a separate `bootsnap-rails` gem?

cc @SamSaffron 