### PR TITLE
Respect `Kernel#require`'s duck-type

### DIFF
--- a/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb
+++ b/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb
@@ -6,7 +6,8 @@ module Kernel
   alias_method(:require_without_bootsnap, :require)
 
   def require(path)
-    string_path = path.to_s
+    path_path = path.respond_to?(:to_path) ? path.to_path : path
+    string_path = String.try_convert(path_path) || raise(TypeError, "no implicit conversion of #{path_path.class} into String")
     return false if Bootsnap::LoadPathCache.loaded_features_index.key?(string_path)
 
     resolved = Bootsnap::LoadPathCache.load_path_cache.find(string_path)


### PR DESCRIPTION
`Kernel#require` turns its argument into a path by calling `to_path` if it responds to it, and then into a String (the argument or the return value of `to_path`) by using implicit conversion (`to_str`).

We can see this in the spec: https://github.com/ruby/spec/blob/97364ff1f90e63ba0159216f9563318a0d97dceb/core/kernel/shared/require.rb#L51

* it calls #to_str on non-String objects
* it calls #to_path on non-String objects
* it calls #to_str on non-String objects returned by #to_path

Or in MRI, in `rb_get_path`, called from `require_internal`:
https://github.com/ruby/ruby/blob/5e3a32021849718ae483eaaa9fbf155f91828039/file.c#L219-L221

---

I used a fork because I noticed none of the tests were loading the core ext (even the test below this one supposedly testing `load`, I'll follow-up on that) and wanted to avoid leaks for other tests.