### PR TITLE
YAML compile cache: encoding aware symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Unreleased
 
+* Improve the YAML compile cache to support `UTF-8` symbols. (#398)
+  [The default `MessagePack` symbol serializer assumes all symbols are ASCII](https://github.com/msgpack/msgpack-ruby/pull/211),
+  because of this, non-ASCII compatible symbol would be restored with `ASCII_8BIT` encoding (AKA `BINARY`).
+  Bootsnap now properly cache them in `UTF-8`.
+
+  Note that the above only apply for actual YAML symbols (e..g `--- :foo`).
+  The issue is still present for string keys parsed with `YAML.load_file(..., symbolize_names: true)`, that is a bug
+  in `msgpack` that will hopefully be solved soon, see: https://github.com/msgpack/msgpack-ruby/pull/246
+
+* Entirely disable the YAML compile cache if `Encoding.default_internal` is set to an encoding not supported by `msgpack`. (#398)
+  `Psych` coerce strings to `Encoding.default_internal`, but `MessagePack` doesn't. So in this scenario we can't provide
+  YAML caching at all without returning the strings in the wrong encoding.
+  This never came up in practice but might as well be safe.
+
 # 1.10.2
 
 * Reduce the `Kernel.require` extra stack frames some more. Now bootsnap should only add one extra frame per `require` call.

--- a/ext/bootsnap/bootsnap.c
+++ b/ext/bootsnap/bootsnap.c
@@ -75,7 +75,7 @@ struct bs_cache_key {
 STATIC_ASSERT(sizeof(struct bs_cache_key) == KEY_SIZE);
 
 /* Effectively a schema version. Bumping invalidates all previous caches */
-static const uint32_t current_version = 4;
+static const uint32_t current_version = 5;
 
 /* hash of e.g. "x86_64-darwin17", invalidating when ruby is recompiled on a
  * new OS ABI, etc. */

--- a/test/compile_cache_key_format_test.rb
+++ b/test/compile_cache_key_format_test.rb
@@ -21,7 +21,7 @@ class CompileCacheKeyFormatTest < Minitest::Test
 
   def test_key_version
     key = cache_key_for_file(FILE)
-    exp = [4].pack("L")
+    exp = [5].pack("L")
     assert_equal(exp, key[R[:version]])
   end
 


### PR DESCRIPTION
Ref: https://github.com/msgpack/msgpack-ruby/pull/211
    
The default msgpack Symbol packer/unpacker is not encoding, aware which cause all non-ASCII symbols to be unpacked with `ASCII-8BIT` encoding aka `BINARY`.
    
So we define a custom packer that prefix the symbol name with `1` for UTF-8 symbols, and `0` for the others (ASCII or binary).
    
If `Encoding.default_internal` is set to something MessagePack doesn't support, we entirely disable the YAML cache.

