### PR TITLE
Fix Regexp and Date handling in YAML compile cache

### DIFF
--- a/lib/bootsnap/compile_cache.rb
+++ b/lib/bootsnap/compile_cache.rb
@@ -3,6 +3,9 @@
 module Bootsnap
   module CompileCache
     UNCOMPILABLE = BasicObject.new
+    def UNCOMPILABLE.inspect
+      "<Bootsnap::UNCOMPILABLE>"
+    end
 
     Error = Class.new(StandardError)
     PermissionError = Class.new(Error)

--- a/test/compile_cache/yaml_test.rb
+++ b/test/compile_cache/yaml_test.rb
@@ -185,10 +185,30 @@ class CompileCacheYAMLTest < Minitest::Test
     end
   end
 
+  def test_precompile_regexp
+    Help.set_file("a.yml", ::YAML.dump(foo: /bar/), 100)
+    assert Bootsnap::CompileCache::YAML.precompile("a.yml")
+  end
+
+  def test_precompile_date
+    Help.set_file("a.yml", ::YAML.dump(Date.today), 100)
+    assert Bootsnap::CompileCache::YAML.precompile("a.yml")
+  end
+
+  def test_precompile_object
+    Help.set_file("a.yml", ::YAML.dump(Object.new), 100)
+    refute Bootsnap::CompileCache::YAML.precompile("a.yml")
+  end
+
   if YAML.respond_to?(:unsafe_load_file)
     def test_unsafe_load_file
       Help.set_file("a.yml", "foo: &foo\n  bar: 42\nplop:\n  <<: *foo", 100)
       assert_equal({"foo" => {"bar" => 42}, "plop" => {"bar" => 42}}, FakeYaml.unsafe_load_file("a.yml"))
+    end
+
+    def test_unsafe_load_file_supports_regexp
+      Help.set_file("a.yml", ::YAML.dump(foo: /bar/), 100)
+      assert_equal({foo: /bar/}, FakeYaml.unsafe_load_file("a.yml"))
     end
   end
 


### PR DESCRIPTION
Followup: https://github.com/Shopify/bootsnap/pull/392

A few mistakes were made. We were using `strict_load` in places we shouldn't have, which was preventing to support some extended types such as `Regexp` and `Date`.

This PR also make the error handling a bit stricter and explicit in the YAML cache.