### PR TITLE
Improve handling of chaining #require_relative patch

### DIFF
--- a/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb
+++ b/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb
@@ -35,7 +35,7 @@ module Kernel
 
   alias_method(:require_relative_without_bootsnap, :require_relative)
   def require_relative(path)
-    location = caller_locations(1..1).first
+    location = caller_locations.find { |x| x.base_label != "require_relative" }
     realpath = Bootsnap::LoadPathCache.realpath_cache.call(
       location.absolute_path || location.path, path
     )

--- a/test/load_path_cache/core_ext/kernel_require_relative_test.rb
+++ b/test/load_path_cache/core_ext/kernel_require_relative_test.rb
@@ -33,6 +33,7 @@ module Bootsnap
         FileUtils.rm_rf(@dir1)
         Kernel.module_eval do
           module_function
+
           undef :require_relative
           alias_method :require_relative, :pre_patch_require_relative
           undef :pre_patch_require_relative

--- a/test/load_path_cache/core_ext/kernel_require_relative_test.rb
+++ b/test/load_path_cache/core_ext/kernel_require_relative_test.rb
@@ -26,7 +26,6 @@ module Bootsnap
             pre_patch_require_relative(path)
           end
         end
-
       end
 
       def teardown

--- a/test/load_path_cache/core_ext/kernel_require_relative_test.rb
+++ b/test/load_path_cache/core_ext/kernel_require_relative_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require("test_helper")
+require("bootsnap/load_path_cache")
+
+module Bootsnap
+  module KernelRequireRelativeTest
+    class KernelRequireRelativeTest < MiniTest::Test
+      def setup
+        @initial_dir = Dir.pwd
+        @dir1 = File.realpath(Dir.mktmpdir)
+
+        Bootsnap::LoadPathCache.setup(
+          cache_path: "#{@dir1}/cache",
+          development_mode: true,
+        )
+        FileUtils.touch("#{@dir1}/a.rb")
+        File.open("#{@dir1}/a.rb", "wb") { |f| f.write("require_relative 'b.rb'\n") }
+        FileUtils.touch("#{@dir1}/b.rb")
+
+        # Chaining a relative_require patch after bootsnap's
+        Kernel.module_eval do
+          alias_method :pre_patch_require_relative, :require_relative
+          undef :require_relative
+          def require_relative(path)
+            pre_patch_require_relative(path)
+          end
+        end
+
+      end
+
+      def teardown
+        FileUtils.rm_rf(@dir1)
+        Kernel.module_eval do
+          module_function
+          undef :require_relative
+          alias_method :require_relative, :pre_patch_require_relative
+          undef :pre_patch_require_relative
+        end
+      end
+
+      def test_chaining_require_relative
+        assert(require("#{@dir1}/a.rb"))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Kernel.require_relative could be patched again by other Gems initialized after bootsnap. This change supports the chaining of Kernel.require_relative