### PR TITLE
Drop dependency on FileUtils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Drop dependency on `fileutils`.
+
 * Better respect `Kernel#require` duck typing. While it almost never comes up in practice, `Kernel#require`
   follow a fairly intricate duck-typing protocol on its argument implemented as `rb_get_path(VALUE)` in MRI.
   So when applicable we bind `rb_get_path` and use it for improved compatibility. See #396 and #406.

--- a/test/load_path_cache/store_test.rb
+++ b/test/load_path_cache/store_test.rb
@@ -71,7 +71,7 @@ module Bootsnap
 
         MessagePack.expects(:dump).in_sequence(retries).raises(Errno::EEXIST.new("File exists @ rb_sysopen"))
         MessagePack.expects(:dump).in_sequence(retries).returns(1)
-        FileUtils.expects(:mv).in_sequence(retries)
+        File.expects(:rename).in_sequence(retries)
 
         store.transaction { store.set("a", 1) }
       end


### PR DESCRIPTION
Fix: https://github.com/Shopify/bootsnap/issues/404

But also it's annoying to have delayed `require` like this one.