### PR TITLE
Reduce the cache key to RUBY_REVISION + RUBY_PLATFORM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+* Remove `uname` and other patform specific version from the cache keys. `RUBY_PLATFORM + RUBY_REVISION` should be
+  enough to ensure bytecode compatibility. This should improve caching for alpine based setups. See #409.
+
 # 1.11.1
 
 * Fix the `can't modify frozen Hash` error on load path cache mutation. See #411.

--- a/README.md
+++ b/README.md
@@ -232,9 +232,9 @@ Bootsnap writes a cache file containing a 64 byte header followed by the cache c
 is a cache key including several fields:
 
 * `version`, hardcoded in bootsnap. Essentially a schema version;
-* `ruby_platform`, A hash of `RUBY_PLATFORM` (e.g. x86_64-linux-gnu) variable and glibc version (on Linux) or OS version (`uname -v` on BSD, macOS)
+* `ruby_platform`, A hash of `RUBY_PLATFORM` (e.g. x86_64-linux-gnu) variable.
 * `compile_option`, which changes with `RubyVM::InstructionSequence.compile_option` does;
-* `ruby_revision`, the version of Ruby this was compiled with;
+* `ruby_revision`, A hash of `RUBY_REVISION`, the exact version of Ruby;
 * `size`, the size of the source file;
 * `mtime`, the last-modification timestamp of the source file when it was compiled; and
 * `data_size`, the number of bytes following the header, which we need to read it into a buffer.


### PR DESCRIPTION
Fix: https://github.com/Shopify/bootsnap/issues/409

Various system versions were added, but as far as I could gather it was just overly conservative.

This was reducing the usefulness of bootsnap when using Alpine linux containers.

cc @dhagher: would you mind testing this branch with your app?
