### PR TITLE
test_helper: support platforms where GC compaction is not supported

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,7 +25,11 @@ Bootsnap::CompileCache.setup(cache_dir: cache_dir, iseq: true, yaml: false, json
 if GC.respond_to?(:verify_compaction_references)
   # This method was added in Ruby 3.0.0. Calling it this way asks the GC to
   # move objects around, helping to find object movement bugs.
-  GC.verify_compaction_references(double_heap: true, toward: :empty)
+  begin
+    GC.verify_compaction_references(double_heap: true, toward: :empty)
+  rescue NotImplementedError
+    # some platforms do not support GC compaction
+  end
 end
 
 module TestHandler


### PR DESCRIPTION
Not all platforms support GC compaction. On those, calling
CG.verify_compaction_references raises a NotImplementedError exception.