### PR TITLE
Get rid of the Module#autoload alias method chain

### DIFF
--- a/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb
+++ b/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb
@@ -42,24 +42,3 @@ module Kernel
     end
   end
 end
-
-class Module
-  alias_method(:autoload_without_bootsnap, :autoload)
-  def autoload(const, path)
-    # NOTE: This may defeat LoadedFeaturesIndex, but it's not immediately
-    # obvious how to make it work. This feels like a pretty niche case, unclear
-    # if it will ever burn anyone.
-    #
-    # The challenge is that we don't control the point at which the entry gets
-    # added to $LOADED_FEATURES and won't be able to hook that modification
-    # since it's done in C-land.
-    resolved = Bootsnap::LoadPathCache.load_path_cache.find(Bootsnap.rb_get_path(path))
-    if Bootsnap::LoadPathCache::FALLBACK_SCAN.equal?(resolved)
-      autoload_without_bootsnap(const, path)
-    elsif resolved == false
-      return false
-    else
-      autoload_without_bootsnap(const, resolved || path)
-    end
-  end
-end


### PR DESCRIPTION
Closes: https://github.com/Shopify/bootsnap/issues/416

IIRC I added this back in `bootscale` days to support Ruby 2.2 and older.
Back in those days, `Module#autoload` wouldn't go through `Kernel#require`
but directly call the `rb_require_safe` C routine.

This changed in Ruby 2.3 with https://github.com/ruby/ruby/commit/cd465d552c3a00341f4cb7f1d7a793d0ebcb6cde

Since we no longer support 2.2, we can remove this entirely.

cc @guigs (this branch should fix your problem, I'll do some safety testing and merge in a bit)