### PR TITLE
Add readonly mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Bootsnap.setup(
   load_path_cache:      true,                 # Optimize the LOAD_PATH with a cache
   compile_cache_iseq:   true,                 # Compile Ruby code into ISeq cache, breaks coverage reporting.
   compile_cache_yaml:   true,                 # Compile YAML into a cache
+  readonly:             true,                 # Use the caches but don't update them on miss or stale entries.
 )
 ```
 
@@ -77,6 +78,7 @@ well together, and are both included in a newly-generated Rails applications by 
 - `DISABLE_BOOTSNAP` allows to entirely disable bootsnap.
 - `DISABLE_BOOTSNAP_LOAD_PATH_CACHE` allows to disable load path caching.
 - `DISABLE_BOOTSNAP_COMPILE_CACHE` allows to disable ISeq and YAML caches.
+- `BOOTSNAP_READONLY` configure bootsnap to not update the cache on miss or stale entries.
 - `BOOTSNAP_LOG` configure bootsnap to log all caches misses to STDERR.
 - `BOOTSNAP_IGNORE_DIRECTORIES` a comma separated list of directories that shouldn't be scanned.
   Useful when you have large directories of non-ruby files inside `$LOAD_PATH`.

--- a/lib/bootsnap.rb
+++ b/lib/bootsnap.rb
@@ -40,6 +40,7 @@ module Bootsnap
       development_mode: true,
       load_path_cache: true,
       ignore_directories: nil,
+      readonly: false,
       compile_cache_iseq: true,
       compile_cache_yaml: true,
       compile_cache_json: true
@@ -49,6 +50,7 @@ module Bootsnap
           cache_path: "#{cache_dir}/bootsnap/load-path-cache",
           development_mode: development_mode,
           ignore_directories: ignore_directories,
+          readonly: readonly,
         )
       end
 
@@ -57,6 +59,7 @@ module Bootsnap
         iseq: compile_cache_iseq,
         yaml: compile_cache_yaml,
         json: compile_cache_json,
+        readonly: readonly,
       )
     end
 
@@ -101,6 +104,7 @@ module Bootsnap
           compile_cache_iseq: !ENV["DISABLE_BOOTSNAP_COMPILE_CACHE"],
           compile_cache_yaml: !ENV["DISABLE_BOOTSNAP_COMPILE_CACHE"],
           compile_cache_json: !ENV["DISABLE_BOOTSNAP_COMPILE_CACHE"],
+          readonly: !!ENV["BOOTSNAP_READONLY"],
           ignore_directories: ignore_directories,
         )
 

--- a/lib/bootsnap/compile_cache.rb
+++ b/lib/bootsnap/compile_cache.rb
@@ -10,7 +10,7 @@ module Bootsnap
     Error = Class.new(StandardError)
     PermissionError = Class.new(Error)
 
-    def self.setup(cache_dir:, iseq:, yaml:, json:)
+    def self.setup(cache_dir:, iseq:, yaml:, json:, readonly: false)
       if iseq
         if supported?
           require_relative("compile_cache/iseq")
@@ -36,6 +36,10 @@ module Bootsnap
         elsif $VERBOSE
           warn("[bootsnap/setup] JSON parsing caching is not supported on this implementation of Ruby")
         end
+      end
+
+      if supported? && defined?(Bootsnap::CompileCache::Native)
+        Bootsnap::CompileCache::Native.readonly = readonly
       end
     end
 

--- a/lib/bootsnap/load_path_cache.rb
+++ b/lib/bootsnap/load_path_cache.rb
@@ -28,13 +28,13 @@ module Bootsnap
       alias_method :enabled?, :enabled
       remove_method(:enabled)
 
-      def setup(cache_path:, development_mode:, ignore_directories:)
+      def setup(cache_path:, development_mode:, ignore_directories:, readonly: false)
         unless supported?
           warn("[bootsnap/setup] Load path caching is not supported on this implementation of Ruby") if $VERBOSE
           return
         end
 
-        store = Store.new(cache_path)
+        store = Store.new(cache_path, readonly: readonly)
 
         @loaded_features_index = LoadedFeaturesIndex.new
 

--- a/lib/bootsnap/load_path_cache/store.rb
+++ b/lib/bootsnap/load_path_cache/store.rb
@@ -13,10 +13,11 @@ module Bootsnap
       NestedTransactionError = Class.new(StandardError)
       SetOutsideTransactionNotAllowed = Class.new(StandardError)
 
-      def initialize(store_path)
+      def initialize(store_path, readonly: false)
         @store_path = store_path
         @txn_mutex = Mutex.new
         @dirty = false
+        @readonly = readonly
         load_data
       end
 
@@ -63,7 +64,7 @@ module Bootsnap
       end
 
       def commit_transaction
-        if @dirty
+        if @dirty && !@readonly
           dump_data
           @dirty = false
         end

--- a/test/setup_test.rb
+++ b/test/setup_test.rb
@@ -23,6 +23,7 @@ module Bootsnap
         compile_cache_yaml: true,
         compile_cache_json: true,
         ignore_directories: nil,
+        readonly: false,
       )
 
       Bootsnap.default_setup
@@ -39,6 +40,7 @@ module Bootsnap
         compile_cache_yaml: true,
         compile_cache_json: true,
         ignore_directories: nil,
+        readonly: false,
       )
 
       Bootsnap.default_setup
@@ -55,6 +57,7 @@ module Bootsnap
         compile_cache_yaml: true,
         compile_cache_json: true,
         ignore_directories: nil,
+        readonly: false,
       )
 
       Bootsnap.default_setup
@@ -71,6 +74,7 @@ module Bootsnap
         compile_cache_yaml: false,
         compile_cache_json: false,
         ignore_directories: nil,
+        readonly: false,
       )
 
       Bootsnap.default_setup
@@ -94,6 +98,7 @@ module Bootsnap
         compile_cache_yaml: true,
         compile_cache_json: true,
         ignore_directories: nil,
+        readonly: false,
       )
       Bootsnap.expects(:logger=).with($stderr.method(:puts))
 
@@ -111,6 +116,7 @@ module Bootsnap
         compile_cache_yaml: true,
         compile_cache_json: true,
         ignore_directories: %w[foo bar],
+        readonly: false,
       )
 
       Bootsnap.default_setup


### PR DESCRIPTION
Fix: https://github.com/Shopify/bootsnap/issues/423

When you know that the cache won't be used again, it avoid some useless work and IOs.

Typically this might be the case for dockerized applications. You generate a cache when building the image, but then when you boot the application any cache update won't be persisted, so thre is no point.