### PR TITLE
Treat only StdLib Ruby files as stable.

### DIFF
--- a/lib/bootsnap/load_path_cache/path.rb
+++ b/lib/bootsnap/load_path_cache/path.rb
@@ -115,17 +115,16 @@ module Bootsnap
       STABLE   = :stable
       VOLATILE = :volatile
 
-      # Built-in ruby lib stuff doesn't change, but things can occasionally be
-      # installed into sitedir, which generally lives under libdir.
-      RUBY_LIBDIR  = RbConfig::CONFIG["libdir"]
-      RUBY_SITEDIR = RbConfig::CONFIG["sitedir"]
+      # Condiser Ruby StdLib dir to be stable.
+      RUBY_LIBDIR = RbConfig::CONFIG["rubylibdir"]
+      RUBY_ARCHDIR = RbConfig::CONFIG["rubyarchdir"]
 
       def stability
         @stability ||= if Gem.path.detect { |p| expanded_path.start_with?(p.to_s) }
           STABLE
         elsif Bootsnap.bundler? && expanded_path.start_with?(Bundler.bundle_path.to_s)
           STABLE
-        elsif expanded_path.start_with?(RUBY_LIBDIR) && !expanded_path.start_with?(RUBY_SITEDIR)
+        elsif expanded_path.start_with?(RUBY_LIBDIR) || expanded_path.start_with?(RUBY_ARCHDIR)
           STABLE
         else
           VOLATILE

--- a/test/load_path_cache/path_test.rb
+++ b/test/load_path_cache/path_test.rb
@@ -16,7 +16,7 @@ module Bootsnap
         volatile        = Path.new(__FILE__)
         stable          = Path.new(time_file)
         unknown         = Path.new("/who/knows")
-        lib             = Path.new("#{RbConfig::CONFIG['libdir']}/a")
+        lib             = Path.new("#{RbConfig::CONFIG['rubylibdir']}/a")
         site            = Path.new("#{RbConfig::CONFIG['sitedir']}/b")
         absolute_prefix = RbConfig::CONFIG["host_os"] =~ /mswin|mingw|cygwin/ ? ENV["SystemDrive"] : ""
         bundler         = Path.new("#{absolute_prefix}/bp/3")


### PR DESCRIPTION
This fixes test failure on Fedora:

~~~
  1) Error:
Bootsnap::LoadPathCache::PathTest#test_stability:
NoMethodError: undefined method `pry' for #<Binding:0x00007f34f6608c90>
    /builddir/build/BUILD/bootsnap-1.15.0/usr/share/gems/gems/bootsnap-1.15.0/test/load_path_cache/path_test.rb:25:in `test_stability'
~~~

where the culprit is that Ruby StdLib lives in `/usr/share`, instead of `/usr/lib64`. However, this is the flexibility given by Ruby configuration, so this should be correctly handled.

But it seems, that the real intention always was to consider just Ruby StdLib as stable, because otherwise, there would not be exception for Site dir.

Therefore, cover just the StdLib via `RbConfig::CONFIG["rubylibdir"]` and treat everything else as unstable.

Please note that the arch specific libraries are not Bootsnap concern, therefore `rubyarchdir` is ignored.

Fixes #431