### PR TITLE
Fix the `YAML.load_file` decorator to be as strict as regular YAML.load_file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Unreleased
 
 * Use `RbConfig::CONFIG["rubylibdir"]` instead of `RbConfig::CONFIG["libdir"]` to check for stdlib files. See #431.
+* Fix the cached version of `YAML.load_file` being slightly more permissive than the default `Psych` one. See #434.
+  `Date` and `Time` values are now properly rejected, as well as aliases.
+  If this causes a regression in your application, it is recommended to load *trusted* YAML files with `YAML.unsafe_load_file`.
 
 # 1.15.0
 

--- a/lib/bootsnap/compile_cache/yaml.rb
+++ b/lib/bootsnap/compile_cache/yaml.rb
@@ -65,7 +65,7 @@ module Bootsnap
           end
 
           unless const_defined?(:NoTagsVisitor)
-            visitor = Class.new(Psych::Visitors::ToRuby) do
+            visitor = Class.new(Psych::Visitors::NoAliasRuby) do
               def visit(target)
                 if target.tag
                   raise UnsupportedTags, "YAML tags are not supported: #{target.tag}"
@@ -129,7 +129,10 @@ module Bootsnap
           ast = ::YAML.parse(payload)
           return ast unless ast
 
-          NoTagsVisitor.create.visit(ast)
+          loader = ::Psych::ClassLoader::Restricted.new(["Symbol"], [])
+          scanner = ::Psych::ScalarScanner.new(loader)
+
+          NoTagsVisitor.new(scanner, loader).visit(ast)
         end
       end
 


### PR DESCRIPTION
Fix: #434

Our strictness was based on the incorrect assumption that all extra types would use a tag, which is incorrect as `Time` and `Date` objects can be expressed in regular YAML syntax without the use of `!ruby/object`.