### PR TITLE
Add Ruby 3.2 to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu]
-        ruby: ['2.6', '2.7', '3.0', '3.1', 'ruby-head', 'debug']
+        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2', 'ruby-head', 'debug']
     runs-on: ${{ matrix.os }}-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This ensures the latest Ruby 3.2 works with Bootsnap.