### PR TITLE
Make load path cache work on TruffleRuby

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu]
-        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2', 'ruby-head', 'debug', 'truffleruby']
+        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2', 'ruby-head', 'debug', 'truffleruby', 'truffleruby-head']
     runs-on: ${{ matrix.os }}-latest
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Support YAML and JSON CompileCache on TruffleRuby.
+* Support LoadPathCache on TruffleRuby.
 
 # 1.16.0
 

--- a/lib/bootsnap/compile_cache.rb
+++ b/lib/bootsnap/compile_cache.rb
@@ -53,8 +53,9 @@ module Bootsnap
     end
 
     def self.supported?
-      # only enable on 'ruby' (MRI), POSIX (darwin, linux, *bsd), Windows (RubyInstaller2) and >= 2.3.0
-      %w[ruby truffleruby].include?(RUBY_ENGINE) && RUBY_PLATFORM.match?(/darwin|linux|bsd|mswin|mingw|cygwin/)
+      # only enable on 'ruby' (MRI) and TruffleRuby for POSIX (darwin, linux, *bsd), Windows (RubyInstaller2)
+      %w[ruby truffleruby].include?(RUBY_ENGINE) &&
+        RUBY_PLATFORM.match?(/darwin|linux|bsd|mswin|mingw|cygwin/)
     end
   end
 end

--- a/lib/bootsnap/load_path_cache.rb
+++ b/lib/bootsnap/load_path_cache.rb
@@ -54,8 +54,17 @@ module Bootsnap
       end
 
       def supported?
-        RUBY_ENGINE == "ruby" &&
-          RUBY_PLATFORM =~ /darwin|linux|bsd|mswin|mingw|cygwin/
+        if RUBY_PLATFORM.match?(/darwin|linux|bsd|mswin|mingw|cygwin/)
+          case RUBY_ENGINE
+          when "truffleruby"
+            # https://github.com/oracle/truffleruby/issues/3131
+            RUBY_ENGINE_VERSION >= "23.1.0"
+          when "ruby"
+            true
+          else
+            false
+          end
+        end
       end
     end
   end

--- a/lib/bootsnap/load_path_cache/cache.rb
+++ b/lib/bootsnap/load_path_cache/cache.rb
@@ -24,8 +24,16 @@ module Bootsnap
         @mutex.synchronize { @dirs[dir] }
       end
 
+      TRUFFLERUBY_LIB_DIR_PREFIX = if RUBY_ENGINE == "truffleruby"
+        "#{File.join(RbConfig::CONFIG['libdir'], 'truffle')}#{File::SEPARATOR}"
+      end
+
       # { 'enumerator' => nil, 'enumerator.so' => nil, ... }
       BUILTIN_FEATURES = $LOADED_FEATURES.each_with_object({}) do |feat, features|
+        if TRUFFLERUBY_LIB_DIR_PREFIX && feat.start_with?(TRUFFLERUBY_LIB_DIR_PREFIX)
+          feat = feat.byteslice(TRUFFLERUBY_LIB_DIR_PREFIX.bytesize..-1)
+        end
+
         # Builtin features are of the form 'enumerator.so'.
         # All others include paths.
         next unless feat.size < 20 && !feat.include?("/")

--- a/test/integration/kernel_test.rb
+++ b/test/integration/kernel_test.rb
@@ -8,6 +8,8 @@ module Bootsnap
     include TmpdirHelper
 
     def test_require_symlinked_file_twice
+      skip("https://github.com/oracle/truffleruby/issues/3138") if truffleruby?
+
       setup_symlinked_files
       if RUBY_VERSION >= "3.1"
         # Fixed in https://github.com/ruby/ruby/commit/79a4484a072e9769b603e7b4fbdb15b1d7eccb15 (Ruby 3.1)
@@ -41,6 +43,8 @@ module Bootsnap
     end
 
     def test_require_relative_symlinked_file_twice
+      skip("https://github.com/oracle/truffleruby/issues/3138") if truffleruby?
+
       setup_symlinked_files
       if RUBY_VERSION >= "3.1"
         # Fixed in https://github.com/ruby/ruby/commit/79a4484a072e9769b603e7b4fbdb15b1d7eccb15 (Ruby 3.1)
@@ -83,6 +87,8 @@ module Bootsnap
     end
 
     def test_require_deep_symlinked_file_twice
+      skip("https://github.com/oracle/truffleruby/issues/3138") if truffleruby?
+
       setup_symlinked_files
       if RUBY_VERSION >= "3.1"
         # Fixed in https://github.com/ruby/ruby/commit/79a4484a072e9769b603e7b4fbdb15b1d7eccb15 (Ruby 3.1)
@@ -116,6 +122,8 @@ module Bootsnap
     end
 
     def test_require_relative_deep_symlinked_file_twice
+      skip("https://github.com/oracle/truffleruby/issues/3138") if truffleruby?
+
       setup_symlinked_files
       if RUBY_VERSION >= "3.1"
         # Fixed in https://github.com/ruby/ruby/commit/79a4484a072e9769b603e7b4fbdb15b1d7eccb15 (Ruby 3.1)
@@ -210,6 +218,10 @@ module Bootsnap
         end
       RUBY
       File.symlink("real", "symlink")
+    end
+
+    def truffleruby?
+      RUBY_ENGINE == "truffleruby"
     end
   end
 end


### PR DESCRIPTION
Load Path Cache can work on the latest TruffleRuby (23.1.0 is due out in September) and offers a small speedup on an example project.

It does require an unreleased bug fix (https://github.com/oracle/truffleruby/issues/3131)
so I added `truffleruby-head` to CI to prove that it works on both the current and the next release.

I used a string comparison on `RUBY_ENGINE_VERSION < "23.1.0"` to do that check
which is consistent with other `RUBY_VERSION >= "2.7"` style comparisons used in this repo
and I think will work for the foreseeable future.

A few kernel tests are skipped due to https://github.com/oracle/truffleruby/issues/3138.

A few test assertions had to be changed from "same" to "equal"
to account for TruffleRuby making copies of the strings that end up in `$LOADED_FEATURES`.

TruffleRuby also has a long string prefix on "builtin" features, so i added a bit of code to strip that off
so that the rest of the code is consistent.  Does that make sense?