### PR TITLE
Remove custom permission error code and restore path in read error

### DIFF
--- a/lib/bootsnap/compile_cache.rb
+++ b/lib/bootsnap/compile_cache.rb
@@ -8,7 +8,6 @@ module Bootsnap
     end
 
     Error = Class.new(StandardError)
-    PermissionError = Class.new(Error)
 
     def self.setup(cache_dir:, iseq:, yaml:, json:, readonly: false)
       if iseq
@@ -41,15 +40,6 @@ module Bootsnap
       if supported? && defined?(Bootsnap::CompileCache::Native)
         Bootsnap::CompileCache::Native.readonly = readonly
       end
-    end
-
-    def self.permission_error(path)
-      cpath = Bootsnap::CompileCache::ISeq.cache_dir
-      raise(
-        PermissionError,
-        "bootsnap doesn't have permission to write cache entries in '#{cpath}' " \
-        "(or, less likely, doesn't have permission to read '#{path}')",
-      )
     end
 
     def self.supported?

--- a/lib/bootsnap/compile_cache/iseq.rb
+++ b/lib/bootsnap/compile_cache/iseq.rb
@@ -87,8 +87,6 @@ module Bootsnap
           return nil if defined?(Coverage) && Bootsnap::CompileCache::Native.coverage_running?
 
           Bootsnap::CompileCache::ISeq.fetch(path.to_s)
-        rescue Errno::EACCES
-          Bootsnap::CompileCache.permission_error(path)
         rescue RuntimeError => error
           if error.message =~ /unmatched platform/
             puts("unmatched platform for file #{path}")

--- a/lib/bootsnap/compile_cache/json.rb
+++ b/lib/bootsnap/compile_cache/json.rb
@@ -74,16 +74,12 @@ module Bootsnap
             return super unless (kwargs.keys - ::Bootsnap::CompileCache::JSON.supported_options).empty?
           end
 
-          begin
-            ::Bootsnap::CompileCache::Native.fetch(
-              Bootsnap::CompileCache::JSON.cache_dir,
-              File.realpath(path),
-              ::Bootsnap::CompileCache::JSON,
-              kwargs,
-            )
-          rescue Errno::EACCES
-            ::Bootsnap::CompileCache.permission_error(path)
-          end
+          ::Bootsnap::CompileCache::Native.fetch(
+            Bootsnap::CompileCache::JSON.cache_dir,
+            File.realpath(path),
+            ::Bootsnap::CompileCache::JSON,
+            kwargs,
+          )
         end
 
         ruby2_keywords :load_file if respond_to?(:ruby2_keywords, true)

--- a/lib/bootsnap/compile_cache/yaml.rb
+++ b/lib/bootsnap/compile_cache/yaml.rb
@@ -229,16 +229,12 @@ module Bootsnap
               return super unless (kwargs.keys - CompileCache::YAML.supported_options).empty?
             end
 
-            begin
-              CompileCache::Native.fetch(
-                CompileCache::YAML.cache_dir,
-                File.realpath(path),
-                CompileCache::YAML::Psych4::SafeLoad,
-                kwargs,
-              )
-            rescue Errno::EACCES
-              CompileCache.permission_error(path)
-            end
+            CompileCache::Native.fetch(
+              CompileCache::YAML.cache_dir,
+              File.realpath(path),
+              CompileCache::YAML::Psych4::SafeLoad,
+              kwargs,
+            )
           end
 
           ruby2_keywords :load_file if respond_to?(:ruby2_keywords, true)
@@ -253,16 +249,12 @@ module Bootsnap
               return super unless (kwargs.keys - CompileCache::YAML.supported_options).empty?
             end
 
-            begin
-              CompileCache::Native.fetch(
-                CompileCache::YAML.cache_dir,
-                File.realpath(path),
-                CompileCache::YAML::Psych4::UnsafeLoad,
-                kwargs,
-              )
-            rescue Errno::EACCES
-              CompileCache.permission_error(path)
-            end
+            CompileCache::Native.fetch(
+              CompileCache::YAML.cache_dir,
+              File.realpath(path),
+              CompileCache::YAML::Psych4::UnsafeLoad,
+              kwargs,
+            )
           end
 
           ruby2_keywords :unsafe_load_file if respond_to?(:ruby2_keywords, true)
@@ -309,16 +301,12 @@ module Bootsnap
               return super unless (kwargs.keys - CompileCache::YAML.supported_options).empty?
             end
 
-            begin
-              CompileCache::Native.fetch(
-                CompileCache::YAML.cache_dir,
-                File.realpath(path),
-                CompileCache::YAML::Psych3,
-                kwargs,
-              )
-            rescue Errno::EACCES
-              CompileCache.permission_error(path)
-            end
+            CompileCache::Native.fetch(
+              CompileCache::YAML.cache_dir,
+              File.realpath(path),
+              CompileCache::YAML::Psych3,
+              kwargs,
+            )
           end
 
           ruby2_keywords :load_file if respond_to?(:ruby2_keywords, true)
@@ -333,16 +321,12 @@ module Bootsnap
               return super unless (kwargs.keys - CompileCache::YAML.supported_options).empty?
             end
 
-            begin
-              CompileCache::Native.fetch(
-                CompileCache::YAML.cache_dir,
-                File.realpath(path),
-                CompileCache::YAML::Psych3,
-                kwargs,
-              )
-            rescue Errno::EACCES
-              CompileCache.permission_error(path)
-            end
+            CompileCache::Native.fetch(
+              CompileCache::YAML.cache_dir,
+              File.realpath(path),
+              CompileCache::YAML::Psych3,
+              kwargs,
+            )
           end
 
           ruby2_keywords :unsafe_load_file if respond_to?(:ruby2_keywords, true)

--- a/test/compile_cache/yaml_test.rb
+++ b/test/compile_cache/yaml_test.rb
@@ -245,6 +245,21 @@ class CompileCacheYAMLTest < Minitest::Test
     end
   end
 
+  def test_no_read_permission
+    if RbConfig::CONFIG["host_os"] =~ /mswin|mingw|cygwin/
+      # On windows removing read permission doesn't prevent reading.
+      pass
+    else
+      file = "a.yml"
+      Help.set_file(file, ::YAML.dump(Object.new), 100)
+      FileUtils.chmod(0o000, file)
+      exception = assert_raises(Errno::EACCES) do
+        FakeYaml.load_file(file)
+      end
+      assert_match(file, exception.message)
+    end
+  end
+
   private
 
   def with_default_encoding_internal(encoding)

--- a/test/compile_cache_test.rb
+++ b/test/compile_cache_test.rb
@@ -38,7 +38,7 @@ class CompileCacheTest < Minitest::Test
       # list contents.
       #
       # Since we can't read directories on windows, this specific test doesn't
-      # make sense. In addtion we test read-only files in
+      # make sense. In addition we test read-only files in
       # `test_can_open_read_only_cache` so we are covered testing reading
       # read-only files.
       pass
@@ -48,6 +48,20 @@ class CompileCacheTest < Minitest::Test
       FileUtils.mkdir_p(folder)
       FileUtils.chmod(0o400, folder)
       load(path)
+    end
+  end
+
+  def test_no_read_permission
+    if RbConfig::CONFIG["host_os"] =~ /mswin|mingw|cygwin/
+      # On windows removing read permission doesn't prevent reading.
+      pass
+    else
+      path = Help.set_file("a.rb", "a = a = 3", 100)
+      FileUtils.chmod(0o000, path)
+      exception = assert_raises(LoadError) do
+        load(path)
+      end
+      assert_match(path, exception.message)
     end
   end
 


### PR DESCRIPTION
The existing error message says

> bootsnap doesn't have permission to write cache entries in '#{cache_path}' 
> (or, less likely, doesn't have permission to read '#{path}')"

but at this point i think the error will never be about the cache and only for the original file.

We stopped reporting write errors in
d878622782f8abed46afcbff1385af075c115859
and read errors in
503e9d50805769e9fc5034ed175062810e8f8f54

In that case it seems like we may as well remove the wrapper class and let the original error bubble up...
but when I did that the exception message was the code "bs_fetch:open_current_file:open" rather than mentioning what file path failed to be read.

My C is incredibly rusty; I don't know if this is a good idea.

What do you think? Do we want to do it this way?
Are there other places we should replace the "bs:*" code with the file path (like the fstat that follows?)

Another option would be to keep the ruby method and just simplify the message
(in which case the C code wouldn't have to change).