### PR TITLE
Fix compatibility with Minitest 5.19+

### DIFF
--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -2,7 +2,7 @@
 
 require("test_helper")
 
-class HelperTest < MiniTest::Test
+class HelperTest < Minitest::Test
   include(CompileCacheISeqHelper)
   include(TmpdirHelper)
 

--- a/test/load_path_cache/cache_test.rb
+++ b/test/load_path_cache/cache_test.rb
@@ -4,7 +4,7 @@ require("test_helper")
 
 module Bootsnap
   module LoadPathCache
-    class CacheTest < MiniTest::Test
+    class CacheTest < Minitest::Test
       include LoadPathCacheHelper
 
       def setup

--- a/test/load_path_cache/change_observer_test.rb
+++ b/test/load_path_cache/change_observer_test.rb
@@ -4,7 +4,7 @@ require("test_helper")
 
 module Bootsnap
   module LoadPathCache
-    class ChangeObserverTest < MiniTest::Test
+    class ChangeObserverTest < Minitest::Test
       include LoadPathCacheHelper
 
       def setup

--- a/test/load_path_cache/core_ext/kernel_require_test.rb
+++ b/test/load_path_cache/core_ext/kernel_require_test.rb
@@ -33,7 +33,7 @@ module Bootsnap
     end
   end
 
-  class KernelLoadTest < MiniTest::Test
+  class KernelLoadTest < Minitest::Test
     def setup
       @initial_dir = Dir.pwd
       @dir1 = File.realpath(Dir.mktmpdir)

--- a/test/load_path_cache/loaded_features_index_test.rb
+++ b/test/load_path_cache/loaded_features_index_test.rb
@@ -4,7 +4,7 @@ require("test_helper")
 
 module Bootsnap
   module LoadPathCache
-    class LoadedFeaturesIndexTest < MiniTest::Test
+    class LoadedFeaturesIndexTest < Minitest::Test
       include LoadPathCacheHelper
 
       def setup

--- a/test/load_path_cache/path_scanner_test.rb
+++ b/test/load_path_cache/path_scanner_test.rb
@@ -4,7 +4,7 @@ require("test_helper")
 
 module Bootsnap
   module LoadPathCache
-    class PathScannerTest < MiniTest::Test
+    class PathScannerTest < Minitest::Test
       include LoadPathCacheHelper
 
       DLEXT = RbConfig::CONFIG["DLEXT"]

--- a/test/load_path_cache/path_test.rb
+++ b/test/load_path_cache/path_test.rb
@@ -5,7 +5,7 @@ require("bootsnap/load_path_cache")
 
 module Bootsnap
   module LoadPathCache
-    class PathTest < MiniTest::Test
+    class PathTest < Minitest::Test
       include LoadPathCacheHelper
 
       def setup

--- a/test/load_path_cache/store_test.rb
+++ b/test/load_path_cache/store_test.rb
@@ -6,7 +6,7 @@ require("fileutils")
 
 module Bootsnap
   module LoadPathCache
-    class StoreTest < MiniTest::Test
+    class StoreTest < Minitest::Test
       include LoadPathCacheHelper
 
       def setup

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -60,7 +60,7 @@ module NullCache
   end
 end
 
-module MiniTest
+module Minitest
   class Test
     module Help
       class << self


### PR DESCRIPTION
The `MiniTest` was renamed to `Minitest`:

https://github.com/minitest/minitest/commit/9a57c520ceac76abfe6105866f8548a94eb357b6

And the `MiniTest` constant is now loaded just when `MT_COMPAT` environment variable is set:

https://github.com/minitest/minitest/commit/a2c6c18570f6f0a1bf6af70fe3b6d9599a13fdd6