### PR TITLE
Fix $LOAD_PATH.dup to be Ractor shareable

### DIFF
--- a/lib/bootsnap/load_path_cache/change_observer.rb
+++ b/lib/bootsnap/load_path_cache/change_observer.rb
@@ -54,6 +54,18 @@ module Bootsnap
             ret
           end
         end
+
+        def dup
+          new_obj = super
+          new_obj.remove_instance_variable(:@lpc_observer)
+          new_obj
+        end
+
+        def clone
+          new_obj = super
+          ChangeObserver.unregister(new_obj)
+          new_obj
+        end
       end
 
       def self.register(arr, observer)


### PR DESCRIPTION
This fixes an incompatiblity with `did_you_mean`, where we will receive an error on the following line:

https://github.com/ruby/did_you_mean/blob/b5f83b2eeaf6344766174123ccaa7a58ddd579e3/lib/did_you_mean/spell_checkers/require_path_checker.rb#L12

This would result in the following error:

```
Error: can not make shareable object for #<Thread::Mutex:0x0000000103042de8>
<internal:ractor>:820:in `make_shareable'
/opt/homebrew/Library/Homebrew/vendor/portable-ruby/3.1.4/lib/ruby/3.1.0/did_you_mean/spell_checkers/require_path_checker.rb:12:in `<class:RequirePathChecker>'
/opt/homebrew/Library/Homebrew/vendor/portable-ruby/3.1.4/lib/ruby/3.1.0/did_you_mean/spell_checkers/require_path_checker.rb:8:in `<module:DidYouMean>'
/opt/homebrew/Library/Homebrew/vendor/portable-ruby/3.1.4/lib/ruby/3.1.0/did_you_mean/spell_checkers/require_path_checker.rb:7:in `<main>'
/opt/homebrew/Library/Homebrew/vendor/portable-ruby/3.1.4/lib/ruby/3.1.0/did_you_mean.rb:9:in `require_relative'
/opt/homebrew/Library/Homebrew/vendor/portable-ruby/3.1.4/lib/ruby/3.1.0/did_you_mean.rb:9:in `<main>'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.1.0/gems/bootsnap-1.16.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.1.0/gems/bootsnap-1.16.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
...
```

This was because `ChangeObserver` adds an ivar containing a Mutex to `$LOAD_PATH`. We however don't need the ivar on `dup`ed load paths so we can add an override that removes it from them.