### PR TITLE
Fix ignore_directories not taking effect

### DIFF
--- a/lib/bootsnap/load_path_cache.rb
+++ b/lib/bootsnap/load_path_cache.rb
@@ -38,8 +38,8 @@ module Bootsnap
 
         @loaded_features_index = LoadedFeaturesIndex.new
 
-        @load_path_cache = Cache.new(store, $LOAD_PATH, development_mode: development_mode)
         PathScanner.ignored_directories = ignore_directories if ignore_directories
+        @load_path_cache = Cache.new(store, $LOAD_PATH, development_mode: development_mode)
         @enabled = true
         require_relative("load_path_cache/core_ext/kernel_require")
         require_relative("load_path_cache/core_ext/loaded_features")


### PR DESCRIPTION
`Cache.new` calls `reinitialize` which starts the `PathScanner` walk so `ignored_directories` should be set before doing that.