### PR TITLE
Support absolute paths in ignore_directories

### DIFF
--- a/lib/bootsnap/load_path_cache/path_scanner.rb
+++ b/lib/bootsnap/load_path_cache/path_scanner.rb
@@ -54,7 +54,7 @@ module Bootsnap
 
             absolute_path = "#{absolute_dir_path}/#{name}"
             if File.directory?(absolute_path)
-              next if ignored_directories.include?(name)
+              next if ignored_directories.include?(name) || ignored_directories.include?(absolute_path)
 
               if yield relative_path, absolute_path, true
                 walk(absolute_path, relative_path, &block)


### PR DESCRIPTION
I want to ignore a `vendor` directory but some gems do legitmately have their own `vendor` directories. Selecting which directory via an absolute path would solve that and it seems trivial to add support for that here.