### PR TITLE
Improve the `Kernel#require` patch to avoid warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Improved the `Kernel#require` decorator to not cause a method redefinition warning. See #461.
+
 # 1.17.0
 
 * Ensure `$LOAD_PATH.dup` is Ractor shareable to fix an conflict with `did_you_mean`.

--- a/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb
+++ b/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 module Kernel
-  module_function
+  alias_method :require_without_bootsnap, :require
 
-  alias_method(:require_without_bootsnap, :require)
+  alias_method :require, :require # Avoid method redefinition warnings
 
-  def require(path)
+  def require(path) # rubocop:disable Lint/DuplicateMethods
     return require_without_bootsnap(path) unless Bootsnap::LoadPathCache.enabled?
 
     string_path = Bootsnap.rb_get_path(path)
@@ -34,4 +34,6 @@ module Kernel
       return ret
     end
   end
+
+  private :require
 end


### PR DESCRIPTION
Fix: https://github.com/Shopify/bootsnap/issues/461

Also neither Rubygems nor Zeitwerk bother decorating `Kernel.require`, and no-one requires with `Kernel.require` so likely not worth it, and if anything that offers an escape hatch to bypass Bootsnap.