### PR TITLE
Revalidate cache based on source digest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+* Revalidate stale cache entries by digesting the source content.
+  This should significantly improve performance in environments where `mtime` isn't preserved (e.g. CI systems doing a git clone, etc).
+  See #468.
 * Open source files and cache entries with `O_NOATIME` when available to reduce disk accesses. See #469.
 * `bootsnap precompile --gemfile` now look for `.rb` files in the whole gem and not just the `lib/` directory. See #466.
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Bootsnap cache misses can be monitored though a callback:
 Bootsnap.instrumentation = ->(event, path) { puts "#{event} #{path}" }
 ```
 
-`event` is either `:miss` or `:stale`. You can also call `Bootsnap.log!` as a shortcut to
+`event` is either `:miss`, `:stale` or `:revalidated`. You can also call `Bootsnap.log!` as a shortcut to
 log all events to STDERR.
 
 To turn instrumentation back off you can set it to nil:

--- a/ext/bootsnap/extconf.rb
+++ b/ext/bootsnap/extconf.rb
@@ -3,6 +3,8 @@
 require "mkmf"
 
 if %w[ruby truffleruby].include?(RUBY_ENGINE)
+  have_func "fdatasync", "fcntl.h"
+
   unless RUBY_PLATFORM.match?(/mswin|mingw|cygwin/)
     append_cppflags ["_GNU_SOURCE"] # Needed of O_NOATIME
   end

--- a/test/compile_cache_key_format_test.rb
+++ b/test/compile_cache_key_format_test.rb
@@ -22,7 +22,7 @@ class CompileCacheKeyFormatTest < Minitest::Test
 
   def test_key_version
     key = cache_key_for_file(FILE)
-    exp = [4].pack("L")
+    exp = [5].pack("L")
     assert_equal(exp, key[R[:version]])
   end
 

--- a/test/load_path_cache/core_ext/kernel_require_test.rb
+++ b/test/load_path_cache/core_ext/kernel_require_test.rb
@@ -12,7 +12,7 @@ module Bootsnap
         assert_nil LoadPathCache.load_path_cache
         cache = Tempfile.new("cache")
         pid = Process.fork do
-          LoadPathCache.setup(cache_path: cache, development_mode: true, ignore_directories: nil)
+          LoadPathCache.setup(cache_path: cache.path, development_mode: true, ignore_directories: nil)
           dir = File.realpath(Dir.mktmpdir)
           $LOAD_PATH.push(dir)
           FileUtils.touch("#{dir}/a.rb")
@@ -40,7 +40,7 @@ module Bootsnap
         assert_nil LoadPathCache.load_path_cache
         cache = Tempfile.new("cache")
         pid = Process.fork do
-          LoadPathCache.setup(cache_path: cache, development_mode: false, ignore_directories: nil)
+          LoadPathCache.setup(cache_path: cache.path, development_mode: false, ignore_directories: nil)
           require("prism")
         end
         _, status = Process.wait2(pid)
@@ -53,7 +53,10 @@ module Bootsnap
   end
 
   class KernelLoadTest < Minitest::Test
+    include TmpdirHelper
+
     def setup
+      super
       @initial_dir = Dir.pwd
       @dir1 = File.realpath(Dir.mktmpdir)
       FileUtils.touch("#{@dir1}/a.rb")
@@ -70,6 +73,7 @@ module Bootsnap
       Dir.chdir(@initial_dir)
       FileUtils.rm_rf(@dir1)
       FileUtils.rm_rf(@dir2)
+      super
     end
 
     def test_no_exstensions_for_kernel_load


### PR DESCRIPTION
Ref: https://github.com/Shopify/bootsnap/issues/336

Bootsnap was initially designed for improving boot time in development, so it was logical to use `mtime` to detect changes given that's reliable on a given machine.

But is just as useful on production and CI environments, however there its hit rate can vary a lot because depending on how the source code and caches are saved and restored, many if not all `mtime` will have changed.

To improve this, we can first try to revalidate using the `mtime`, and if it fails, fallback to compare a digest of the file content. Digesting a file, even with `fnv1a_64` is of course an overhead, but the assumption is that true misses should be relatively rare and that digesting the file will always be faster than compiling it. So even if it only improve the hit rate marginally, it should be faster overall.

Also we only recompute the digest if the file mtime changed, but its size remained the same, which should discard the overwhelming majority of legitimate source file changes.