### PR TITLE
Dont revalidate on windows

### DIFF
--- a/test/compile_cache_test.rb
+++ b/test/compile_cache_test.rb
@@ -160,6 +160,8 @@ class CompileCacheTest < Minitest::Test
   end
 
   def test_dont_revalidate_when_readonly
+    skip("Not on Windows") if RUBY_PLATFORM.match?(/mswin|mingw|cygwin/)
+
     path = Help.set_file("a.rb", "a = a = 3", 100)
     load(path)
 
@@ -220,6 +222,8 @@ class CompileCacheTest < Minitest::Test
   end
 
   def test_instrumentation_revalidate
+    skip("Not on Windows") if RUBY_PLATFORM.match?(/mswin|mingw|cygwin/)
+
     file_path = Help.set_file("a.rb", "a = a = 3", 100)
     load(file_path)
     FileUtils.touch("a.rb", mtime: File.mtime("a.rb") + 42)


### PR DESCRIPTION
Hoping to fix:

```
 1) Failure:
CompileCacheHandlerErrorsTest#test_input_to_output_unexpected_type [test/compile_cache_handler_errors_test.rb:61]:
not all expectations were satisfied
unsatisfied expectations:
- expected exactly once, invoked never: Bootsnap::CompileCache::ISeq.input_to_output(any_parameters)
- expected exactly once, invoked never: Bootsnap::CompileCache::ISeq.input_to_storage(any_parameters)
```

To be fair that test is a bit weird, but I don't really have much ways to debug windows anyway.