### PR TITLE
Define _GNU_SOURCE properly

### DIFF
--- a/ext/bootsnap/extconf.rb
+++ b/ext/bootsnap/extconf.rb
@@ -6,7 +6,7 @@ if %w[ruby truffleruby].include?(RUBY_ENGINE)
   have_func "fdatasync", "unistd.h"
 
   unless RUBY_PLATFORM.match?(/mswin|mingw|cygwin/)
-    append_cppflags ["_GNU_SOURCE"] # Needed of O_NOATIME
+    append_cppflags ["-D_GNU_SOURCE"] # Needed of O_NOATIME
   end
 
   append_cflags ["-O3", "-std=c99"]


### PR DESCRIPTION
extconf output shows that it was passing _GNU_SOURCE as a command line
argument and it was failing:

    checking for whether _GNU_SOURCE is accepted as CPPFLAGS... no
