### PR TITLE
Fix a cache corruption issue during revalidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Fix the cache corruption issue in the revalidation feature. See #474.
+
 # 1.18.2
 
 * Disable stale cache entries revalidation by default as it seems to cause cache corruption issues. See #471 and #474.


### PR DESCRIPTION
Fix: https://github.com/Shopify/bootsnap/issues/474
Fix: https://github.com/Shopify/bootsnap/issues/471

As noticed by Stan Hu, upon revalidation, we'd corrupt the `data_size` field, as it wasn't initialized at all on the cache key we computed from the source file.

The only thing we actually want to update is the `mtime`.

Co-Authored-By: @stanhu (we didn't pair, but spotting the root cause was 99% of the work, so...)

For now I leave the revalidation as optional, but will likely flip it back on in another release next week, once it has run for a while on our CI without issues.