### PR TITLE
Fix startup failure if the cache directory points to a broken symlink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Fix startup failure if the cache directory points to a broken symlink.
+
 # 1.18.3
 
 * Fix the cache corruption issue in the revalidation feature. See #474.

--- a/lib/bootsnap/load_path_cache/store.rb
+++ b/lib/bootsnap/load_path_cache/store.rb
@@ -122,6 +122,8 @@ module Bootsnap
         stack.reverse_each do |dir|
           Dir.mkdir(dir)
         rescue SystemCallError
+          # Check for broken symlinks. Calling File.realpath will raise Errno::ENOENT if that is the case
+          File.realpath(dir) if File.symlink?(dir)
           raise unless File.directory?(dir)
         end
       end

--- a/test/load_path_cache/store_test.rb
+++ b/test/load_path_cache/store_test.rb
@@ -85,6 +85,13 @@ module Bootsnap
         store.transaction { store.set("a", 1) }
       end
 
+      def test_with_broken_symlink
+        FileUtils.ln_s(@path, "#{@dir}/store_broken")
+        store = Store.new("#{@dir}/store_broken/store")
+
+        store.transaction { store.set("a", "b") }
+      end
+
       def test_ignore_read_only_filesystem
         MessagePack.expects(:dump).raises(Errno::EROFS.new("Read-only file system @ rb_sysopen"))
         store.transaction { store.set("a", 1) }


### PR DESCRIPTION
Discovered in https://github.com/Shopify/ruby-lsp-rails/issues/278

If the cache directory is a symlink and points to another directory that doesn't exist, saving the cache will fall into an infinite loop. This is because of the retry logic at https://github.com/Shopify/bootsnap/blob/8394834cd504548aae3b4651587abd823f0495d1/lib/bootsnap/load_path_cache/store.rb#L107-L108

This patch forces a different error by trying to resolve the symlink. Calling `File.realpath` on a broken symlink will raise `Errno::ENOENT` which will not be retried.

A setup explanation to even end up in this state is provided at https://github.com/Shopify/ruby-lsp-rails/issues/278#issuecomment-1976096531

@mttkay can you check if this fixes the issue for you? 