### PR TITLE
Remove coverage workaround

### DIFF
--- a/ext/bootsnap/bootsnap.c
+++ b/ext/bootsnap/bootsnap.c
@@ -146,15 +146,6 @@ struct s2o_data;
 struct i2o_data;
 struct i2s_data;
 
-/* https://bugs.ruby-lang.org/issues/13667 */
-extern VALUE rb_get_coverages(void);
-static VALUE
-bs_rb_coverage_running(VALUE self)
-{
-  VALUE cov = rb_get_coverages();
-  return RTEST(cov) ? Qtrue : Qfalse;
-}
-
 static VALUE
 bs_rb_get_path(VALUE self, VALUE fname)
 {
@@ -193,7 +184,6 @@ Init_bootsnap(void)
   rb_define_module_function(rb_mBootsnap, "instrumentation_enabled=", bs_instrumentation_enabled_set, 1);
   rb_define_module_function(rb_mBootsnap_CompileCache_Native, "readonly=", bs_readonly_set, 1);
   rb_define_module_function(rb_mBootsnap_CompileCache_Native, "revalidation=", bs_revalidation_set, 1);
-  rb_define_module_function(rb_mBootsnap_CompileCache_Native, "coverage_running?", bs_rb_coverage_running, 0);
   rb_define_module_function(rb_mBootsnap_CompileCache_Native, "fetch", bs_rb_fetch, 4);
   rb_define_module_function(rb_mBootsnap_CompileCache_Native, "precompile", bs_rb_precompile, 3);
   rb_define_module_function(rb_mBootsnap_CompileCache_Native, "compile_option_crc32=", bs_compile_option_crc32_set, 1);

--- a/lib/bootsnap/compile_cache/iseq.rb
+++ b/lib/bootsnap/compile_cache/iseq.rb
@@ -84,7 +84,7 @@ module Bootsnap
       module InstructionSequenceMixin
         def load_iseq(path)
           # Having coverage enabled prevents iseq dumping/loading.
-          return nil if defined?(Coverage) && Bootsnap::CompileCache::Native.coverage_running?
+          return nil if defined?(Coverage) && Coverage.running?
 
           Bootsnap::CompileCache::ISeq.fetch(path.to_s)
         rescue RuntimeError => error

--- a/test/compile_cache_test.rb
+++ b/test/compile_cache_test.rb
@@ -21,12 +21,13 @@ class CompileCacheTest < Minitest::Test
     end
   end
 
-  def test_coverage_running?
-    refute(Bootsnap::CompileCache::Native.coverage_running?)
+  def test_coverage_running
     require "coverage"
+    Bootsnap::CompileCache::ISeq.expects(:fetch).times(0)
     begin
       Coverage.start
-      assert(Bootsnap::CompileCache::Native.coverage_running?)
+      path = Help.set_file("a.rb", "a = a = 3", 100)
+      load(path)
     ensure
       Coverage.result
     end


### PR DESCRIPTION
The `running?` method has been added in Ruby 2.4. I've also tweaked the test to check that it actually returns early.