### PR TITLE
Fix bootsnap setup in environments without bundler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Allow using bootsnap without bundler. See #488.
 * Fix startup failure if the cache directory points to a broken symlink.
 
 # 1.18.3

--- a/lib/bootsnap/explicit_require.rb
+++ b/lib/bootsnap/explicit_require.rb
@@ -25,6 +25,11 @@ module Bootsnap
     # This is useful before bootsnap is fully-initialized to load gems that it
     # depends on, without forcing full LOAD_PATH traversals.
     def self.with_gems(*gems)
+      # Ensure the gems are activated (their paths are in $LOAD_PATH)
+      gems.each do |gem_name|
+        gem gem_name
+      end
+
       orig = $LOAD_PATH.dup
       $LOAD_PATH.clear
       gems.each do |gem|


### PR DESCRIPTION
Fix: https://github.com/Shopify/bootsnap/issues/488

`ExplicitRequire.with_gems` assumed the provided gems were activated which is only true if `bundler/setup` was required.

If bootsnap is used without bundler, then we need to explictly activate the gem before mutating the `$LOAD_PATH`, otherwise the paths appended during gems activation will be lost once we exit `with_gems`.

FYI: @fxn 