### PR TITLE
Support Unicode Gem path

### DIFF
--- a/lib/bootsnap/load_path_cache/path.rb
+++ b/lib/bootsnap/load_path_cache/path.rb
@@ -22,7 +22,11 @@ module Bootsnap
       attr_reader(:path)
 
       def initialize(path, real: false)
-        @path = path.to_s.freeze
+        @path = path.to_s
+        if @path.encoding == Encoding::ASCII_8BIT
+          @path = @path.dup.force_encoding('UTF-8')
+        end
+        @path.freeze
         @real = real
       end
 


### PR DESCRIPTION
I'm using RVM and my `$HOME` is located at `/home/Dāvis` which means GEM path is at `/home/Dāvis/.rvm/rubies/ruby-3.3.4/lib/ruby/gems/`

Currently this causes bootsnap to fail with
```
/home/Dāvis/.rvm/rubies/ruby-3.3.4/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/path.rb:124:in `start_with?': incompatible character encodings: ASCII-8BIT and UTF-8 (Encoding::CompatibilityError)
        from /home/Dāvis/.rvm/rubies/ruby-3.3.4/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/path.rb:124:in `block in stability'
        from /home/Dāvis/.rvm/rubies/ruby-3.3.4/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/path.rb:124:in `each'
        from /home/Dāvis/.rvm/rubies/ruby-3.3.4/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/path.rb:124:in `detect'
        from /home/Dāvis/.rvm/rubies/ruby-3.3.4/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/path.rb:124:in `stability'
        from /home/Dāvis/.rvm/rubies/ruby-3.3.4/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/path.rb:12:in `stable?'
        from /home/Dāvis/.rvm/rubies/ruby-3.3.4/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/path.rb:60:in `entries_and_dirs'
        from /home/Dāvis/.rvm/rubies/ruby-3.3.4/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/cache.rb:155:in `block (2 levels) in push_paths_locked'
        from /home/Dāvis/.rvm/rubies/ruby-3.3.4/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/cache.rb:147:in `each'
        from /home/Dāvis/.rvm/rubies/ruby-3.3.4/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/cache.rb:147:in `block in push_paths_locked'
        from /home/Dāvis/.rvm/rubies/ruby-3.3.4/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/store.rb:53:in `block in transaction'
        from /home/Dāvis/.rvm/rubies/ruby-3.3.4/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/store.rb:52:in `synchronize'
        from /home/Dāvis/.rvm/rubies/ruby-3.3.4/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/store.rb:52:in `transaction'
        from /home/Dāvis/.rvm/rubies/ruby-3.3.4/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/cache.rb:146:in `push_paths_locked'
        from /home/Dāvis/.rvm/rubies/ruby-3.3.4/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/cache.rb:119:in `block in push_paths'
        from /home/Dāvis/.rvm/rubies/ruby-3.3.4/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/cache.rb:119:in `synchronize'
        from /home/Dāvis/.rvm/rubies/ruby-3.3.4/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/cache.rb:119:in `push_paths'
        from /home/Dāvis/.rvm/rubies/ruby-3.3.4/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/change_observer.rb:11:in `<<'
```

This is because `Gem.path` is at `["/home/Dāvis/.rvm/rubies/ruby-3.3.4/lib/ruby/gems/3.3.0"]` and it's UTF-8 encoded while sometimes `path` can be with `ASCII-8BIT` encoding.

Note that there is similar issue within Ruby aswell, see ruby/ruby#11958
