### PR TITLE
Add latest release to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 1.18.6
+
 * Fix cgroup CPU limits detection in CLI.
 
 # 1.18.5


### PR DESCRIPTION
I can see in RubyGems that version 1.18.6 is out. And based on commits 86efe7df5e3b19b0ba550206a9e03a5c6499d3b0 and dc98453267575068a3aac65b8653382acd2f84a7, I understand that it includes the cgroup CPU limits fix — and nothing else since 1.18.5.

Therefore I believe 1.18.6 can be added to the changelog.