### PR TITLE
Implement PathScanner in C to avoid N+1 `stat(2)` calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Optimized load path scanning with a C extension. Should be about 2x faster on supported platforms.
+
 # 1.19.0
 
 * Remove JSON parsing cache. Recent versions of the `json` gem are as fast as `msgpack` if not faster.

--- a/Gemfile
+++ b/Gemfile
@@ -17,4 +17,5 @@ gem "mocha"
 
 group :development do
   gem "rubocop", "~> 1.50.2" # Ruby 2.6 support
+  gem "base64"
 end

--- a/ext/bootsnap/extconf.rb
+++ b/ext/bootsnap/extconf.rb
@@ -4,6 +4,7 @@ require "mkmf"
 
 if %w[ruby truffleruby].include?(RUBY_ENGINE)
   have_func "fdatasync", "unistd.h"
+  have_func "fstatat", "sys/stat.h"
 
   unless RUBY_PLATFORM.match?(/mswin|mingw|cygwin/)
     append_cppflags ["-D_GNU_SOURCE"] # Needed of O_NOATIME

--- a/lib/bootsnap.rb
+++ b/lib/bootsnap.rb
@@ -2,8 +2,8 @@
 
 require_relative "bootsnap/version"
 require_relative "bootsnap/bundler"
-require_relative "bootsnap/load_path_cache"
 require_relative "bootsnap/compile_cache"
+require_relative "bootsnap/load_path_cache"
 
 module Bootsnap
   InvalidConfiguration = Class.new(StandardError)

--- a/lib/bootsnap/load_path_cache/cache.rb
+++ b/lib/bootsnap/load_path_cache/cache.rb
@@ -11,7 +11,15 @@ module Bootsnap
         @development_mode = development_mode
         @store = store
         @mutex = Mutex.new
-        @path_obj = path_obj.map! { |f| PathScanner.os_path(File.exist?(f) ? File.realpath(f) : f.dup) }
+        @path_obj = path_obj.map! do |f|
+          if File.exist?(f)
+            File.realpath(f).freeze
+          elsif f.frozen?
+            f
+          else
+            f.dup.freeze
+          end
+        end
         @has_relative_paths = nil
         reinitialize
       end

--- a/test/load_path_cache/path_scanner_test.rb
+++ b/test/load_path_cache/path_scanner_test.rb
@@ -32,6 +32,14 @@ module Bootsnap
           assert_equal(["a", "b", "b/c", "h", "h/i", "l", "l/m"], dirs.sort)
         end
       end
+
+      def test_scan_missing_or_invalid_dir
+        Dir.mktmpdir do |dir|
+          assert_equal [[], []], PathScanner.call("#{dir}/does/not/exist")
+          File.write("#{dir}/file", "")
+          assert_equal [[], []], PathScanner.call("#{dir}/file")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Context: https://bugs.ruby-lang.org/issues/21800

When iterating a directory, we need for each entry to know if it's a regular file or a directory. In C we can know that directly via the `readdir` API, but Ruby unfortunately doesn't expose that data (yet).

Benchmarking against a repo with 32235 files, in 10764 directories:

```
ruby 3.4.4 (2025-05-14 revision a38531fd3f) +PRISM [arm64-darwin25]
Warming up --------------------------------------
                orig     1.000 i/100ms
                 opt     1.000 i/100ms
Calculating -------------------------------------
                orig      1.988 (± 0.0%) i/s  (502.94 ms/i) -     10.000 in   5.031382s
                 opt      4.297 (± 0.0%) i/s  (232.70 ms/i) -     22.000 in   5.120236s

Comparison:
                orig:        2.0 i/s
                 opt:        4.3 i/s - 2.16x  faster
```

```ruby
root = ARGV.first
Benchmark.ips do |x|
  x.report("orig") do
    Bootsnap::LoadPathCache::PathScanner.ruby_call(root)
  end

  x.report("opt") do
    Bootsnap::LoadPathCache::PathScanner.native_call(root)
  end

  x.compare!(order: :baseline)
end
```