### PR TITLE
Stop caching directories in LoadPathCache

### DIFF
--- a/test/load_path_cache/cache_test.rb
+++ b/test/load_path_cache/cache_test.rb
@@ -91,13 +91,6 @@ module Bootsnap
         assert_equal("#{@dir1}/conflict.rb", cache.find("conflict"))
       end
 
-      def test_directory_caching
-        cache = Cache.new(NullCache, [@dir1])
-        assert_equal(@dir1, cache.load_dir("foo"))
-        assert_equal(@dir1, cache.load_dir("foo/bar"))
-        assert_nil(cache.load_dir("bar"))
-      end
-
       def test_extension_permutations
         cache = Cache.new(NullCache, [@dir1])
         assert_equal("#{@dir1}/dl#{DLEXT}", cache.find("dl"))

--- a/test/load_path_cache/path_scanner_test.rb
+++ b/test/load_path_cache/path_scanner_test.rb
@@ -27,17 +27,16 @@ module Bootsnap
           FileUtils.ln_s("#{dir}/support/h", "#{dir}/ruby/h")
           FileUtils.ln_s("#{dir}/support/l/m", "#{dir}/ruby/l/m")
 
-          entries, dirs = PathScanner.call("#{dir}/ruby")
+          entries = PathScanner.call("#{dir}/ruby")
           assert_equal(["a/g.rb", "d.rb", "e.#{DLEXT}", "h/i/k.rb", "h/j.rb", "l/m/n.rb"], entries.sort)
-          assert_equal(["a", "b", "b/c", "h", "h/i", "l", "l/m"], dirs.sort)
         end
       end
 
       def test_scan_missing_or_invalid_dir
         Dir.mktmpdir do |dir|
-          assert_equal [[], []], PathScanner.call("#{dir}/does/not/exist")
+          assert_equal [], PathScanner.call("#{dir}/does/not/exist")
           File.write("#{dir}/file", "")
-          assert_equal [[], []], PathScanner.call("#{dir}/file")
+          assert_equal [], PathScanner.call("#{dir}/file")
         end
       end
     end

--- a/test/load_path_cache/path_test.rb
+++ b/test/load_path_cache/path_test.rb
@@ -56,48 +56,48 @@ module Bootsnap
 
       def test_volatile_cache_valid_when_mtime_has_not_changed
         with_caching_fixtures do |dir, _a, _a_b, _a_b_c|
-          entries, dirs = PathScanner.call(dir)
+          entries = PathScanner.call(dir)
           path = Path.new(dir) # volatile, since it'll be in /tmp
 
-          @cache.expects(:get).with(path.expanded_path).returns([100, entries, dirs])
+          @cache.expects(:get).with(path.expanded_path).returns([100, entries])
 
-          path.entries_and_dirs(@cache)
+          path.entries(@cache)
         end
       end
 
       def test_volatile_cache_invalid_when_mtime_changed
         with_caching_fixtures do |dir, _a, a_b, _a_b_c|
-          entries, dirs = PathScanner.call(dir)
+          entries = PathScanner.call(dir)
           path = Path.new(dir) # volatile, since it'll be in /tmp
 
           FileUtils.touch(a_b, mtime: Time.at(101))
 
-          @cache.expects(:get).with(path.expanded_path).returns([100, entries, dirs])
-          @cache.expects(:set).with(path.expanded_path, [101, entries, dirs])
+          @cache.expects(:get).with(path.expanded_path).returns([100, entries])
+          @cache.expects(:set).with(path.expanded_path, [101, entries])
 
           # next read doesn't regen
-          @cache.expects(:get).with(path.expanded_path).returns([101, entries, dirs])
+          @cache.expects(:get).with(path.expanded_path).returns([101, entries])
 
-          path.entries_and_dirs(@cache)
-          path.entries_and_dirs(@cache)
+          path.entries(@cache)
+          path.entries(@cache)
         end
       end
 
       def test_volatile_cache_generated_when_missing
         with_caching_fixtures do |dir, _a, _a_b, _a_b_c|
-          entries, dirs = PathScanner.call(dir)
+          entries = PathScanner.call(dir)
           path = Path.new(dir) # volatile, since it'll be in /tmp
 
           @cache.expects(:get).with(path.expanded_path).returns(nil)
-          @cache.expects(:set).with(path.expanded_path, [100, entries, dirs])
+          @cache.expects(:set).with(path.expanded_path, [100, entries])
 
-          path.entries_and_dirs(@cache)
+          path.entries(@cache)
         end
       end
 
       def test_stable_cache_does_not_notice_when_mtime_changes
         with_caching_fixtures do |dir, _a, a_b, _a_b_c|
-          entries, dirs = PathScanner.call(dir)
+          entries = PathScanner.call(dir)
           path = Path.new(dir) # volatile, since it'll be in /tmp
           path.expects(:stable?).returns(true)
 
@@ -105,9 +105,9 @@ module Bootsnap
 
           # It's unfortunate that we're stubbing the impl of #fetch here.
           PathScanner.expects(:call).never
-          @cache.expects(:get).with(path.expanded_path).returns([100, entries, dirs])
+          @cache.expects(:get).with(path.expanded_path).returns([100, entries])
 
-          path.entries_and_dirs(@cache)
+          path.entries(@cache)
         end
       end
 


### PR DESCRIPTION
This was used to support ActiveSupport::Dependencies but we entirely removed it in bbd7badd0efae7acadbdece33cd005289d3f19db