### PR TITLE
Eagerly clear cache buffers

### DIFF
--- a/lib/bootsnap/compile_cache/iseq.rb
+++ b/lib/bootsnap/compile_cache/iseq.rb
@@ -50,7 +50,9 @@ module Bootsnap
       end
 
       def self.storage_to_output(binary, _args)
-        RubyVM::InstructionSequence.load_from_binary(binary)
+        iseq = RubyVM::InstructionSequence.load_from_binary(binary)
+        binary.clear
+        iseq
       rescue RuntimeError => error
         if error.message == "broken binary format"
           $stderr.puts("[Bootsnap::CompileCache] warning: rejecting broken binary")

--- a/lib/bootsnap/compile_cache/yaml.rb
+++ b/lib/bootsnap/compile_cache/yaml.rb
@@ -170,7 +170,9 @@ module Bootsnap
             unpacker = CompileCache::YAML.msgpack_factory.unpacker(kwargs)
             unpacker.feed(data)
             _safe_loaded = unpacker.unpack
-            unpacker.unpack
+            result = unpacker.unpack
+            data.clear
+            result
           end
 
           def input_to_output(data, kwargs)


### PR DESCRIPTION
By eagerly clearing strings that are likely to be externally allocated we appease the GC malloc heuristic and make it trigger less often.