### PR TITLE
Properly fix opendir failing with `errno = 0`

### DIFF
--- a/ext/bootsnap/bootsnap.c
+++ b/ext/bootsnap/bootsnap.c
@@ -176,24 +176,14 @@ bs_rb_scan_dir(VALUE self, VALUE abspath)
 {
     Check_Type(abspath, T_STRING);
 
-    DIR *dirp = opendir(RSTRING_PTR(abspath));
-
     VALUE dirs = rb_ary_new();
     VALUE requirables = rb_ary_new();
     VALUE result = rb_ary_new_from_args(2, requirables, dirs);
 
+    DIR *dirp = opendir(RSTRING_PTR(abspath));
     if (dirp == NULL) {
         if (errno == ENOTDIR || errno == ENOENT) {
             return result;
-        }
-
-        // BUG: Some users reported a crash here because Ruby's syserr trigger
-        // a crash if called with `errno == 0`.
-        // The opendir spec is quite clear that if it returns NULL, then `errno` must
-        // be set, and yet here we are.
-        // So turning no errno into EINVAL, and from there I hope to get to the bottom of things.
-        if (errno == 0) {
-            errno = EINVAL;
         }
 
         bs_syserr_fail_path("opendir", errno, abspath);

--- a/lib/bootsnap/load_path_cache/path_scanner.rb
+++ b/lib/bootsnap/load_path_cache/path_scanner.rb
@@ -102,13 +102,6 @@ module Bootsnap
             end
 
             all_requirables
-          rescue SystemCallError => error
-            if ENV["BOOTSNAP_DEBUG"]
-              raise
-            else
-              Bootsnap.logger&.call("Unexpected error: #{error.class}: #{error.message}")
-              ruby_call(root_path)
-            end
           end
           alias_method :call, :native_call
         else

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-ENV["BOOTSNAP_DEBUG"] = "1"
-
 $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
 
 if Warning.respond_to?(:[]=)


### PR DESCRIPTION
Thanks to the person who put me on the right track on Reddit.

I believe the bug happens when one of the `rb_ary_new*` triggers a GC, which may invoke code that may reset `errno` (typically a file finalizer).