### PR TITLE
Fix bundle path check and consolidate common code in PathScanner

### DIFF
--- a/lib/bootsnap/load_path_cache/path_scanner.rb
+++ b/lib/bootsnap/load_path_cache/path_scanner.rb
@@ -18,21 +18,12 @@ module Bootsnap
       class << self
         attr_accessor :ignored_directories
 
-        def ruby_call(path)
-          path = File.expand_path(path.to_s).freeze
-          return [] unless File.directory?(path)
-
-          # If the bundle path is a descendent of this path, we do additional
-          # checks to prevent recursing into the bundle path as we recurse
-          # through this path. We don't want to scan the bundle path because
-          # anything useful in it will be present on other load path items.
-          #
-          # This can happen if, for example, the user adds '.' to the load path,
-          # and the bundle path is '.bundle'.
-          contains_bundle_path = BUNDLE_PATH.start_with?(path)
+        def ruby_call(root_path)
+          root_path, contains_bundle_path, ignored_abs_paths, ignored_dir_names = prepare_scan(root_path)
+          return [] unless File.directory?(root_path)
 
           requirables = []
-          walk(path, nil) do |relative_path, absolute_path, is_directory|
+          walk(root_path, nil, ignored_abs_paths, ignored_dir_names) do |relative_path, absolute_path, is_directory|
             if is_directory
               !contains_bundle_path || !absolute_path.start_with?(BUNDLE_PATH)
             elsif relative_path.end_with?(*REQUIRABLE_EXTENSIONS)
@@ -50,19 +41,7 @@ module Bootsnap
           def native_call(root_path)
             # NOTE: if https://bugs.ruby-lang.org/issues/21800 is accepted we should be able
             # to have similar performance with pure Ruby
-
-            # If the bundle path is a descendent of this path, we do additional
-            # checks to prevent recursing into the bundle path as we recurse
-            # through this path. We don't want to scan the bundle path because
-            # anything useful in it will be present on other load path items.
-            #
-            # This can happen if, for example, the user adds '.' to the load path,
-            # and the bundle path is '.bundle'.
-            contains_bundle_path = BUNDLE_PATH.start_with?(root_path)
-
-            ignored_abs_paths, ignored_dir_names = ignored_directories.partition { |p| File.absolute_path?(p) }
-            ignored_abs_paths = nil if ignored_abs_paths.empty?
-            ignored_dir_names = nil if ignored_dir_names.empty?
+            root_path, contains_bundle_path, ignored_abs_paths, ignored_dir_names = prepare_scan(root_path)
 
             all_requirables, queue = Native.scan_dir(root_path)
             all_requirables.each(&:freeze)
@@ -77,18 +56,20 @@ module Bootsnap
               end
             end
 
-            while (path = queue.pop)
-              absolute_base = File.join(root_path, path)
+            while (relative_path = queue.pop)
+              absolute_base = File.join(root_path, relative_path)
               requirables, dirs = Native.scan_dir(absolute_base)
               dirs.reject! do |dir|
-                ignored_dir_names&.include?(dir) || ignored_abs_paths&.include?(File.join(absolute_base, dir))
+                if ignored_dir_names&.include?(dir)
+                  true
+                elsif ignored_abs_paths || contains_bundle_path
+                  absolute_dir = File.join(absolute_base, dir)
+                  ignored_abs_paths&.include?(absolute_dir) ||
+                    (contains_bundle_path && absolute_dir.start_with?(BUNDLE_PATH))
+                end
               end
-              dirs.map! { |f| File.join(path, f).freeze }
-              requirables.map! { |f| File.join(path, f).freeze }
-
-              if contains_bundle_path
-                dirs.reject! { |dir| dir.start_with?(BUNDLE_PATH) }
-              end
+              dirs.map! { |f| File.join(relative_path, f).freeze }
+              requirables.map! { |f| File.join(relative_path, f).freeze }
 
               all_requirables.concat(requirables)
               queue.concat(dirs)
@@ -103,22 +84,37 @@ module Bootsnap
 
         private
 
-        def walk(absolute_dir_path, relative_dir_path, &block)
+        def prepare_scan(root_path)
+          root_path = File.expand_path(root_path.to_s).freeze
+
+          # If the bundle path is a descendent of this path, we do additional
+          # checks to prevent recursing into the bundle path as we recurse
+          # through this path. We don't want to scan the bundle path because
+          # anything useful in it will be present on other load path items.
+          #
+          # This can happen if, for example, the user adds '.' to the load path,
+          # and the bundle path is '.bundle'.
+          contains_bundle_path = BUNDLE_PATH.start_with?(root_path)
+
           ignored_abs_paths, ignored_dir_names = ignored_directories.partition { |p| File.absolute_path?(p) }
           ignored_abs_paths = nil if ignored_abs_paths.empty?
           ignored_dir_names = nil if ignored_dir_names.empty?
 
+          [root_path, contains_bundle_path, ignored_abs_paths, ignored_dir_names]
+        end
+
+        def walk(absolute_dir_path, relative_dir_path, ignored_abs_paths, ignored_dir_names, &block)
           Dir.foreach(absolute_dir_path) do |name|
             next if name.start_with?(".")
 
             relative_path = relative_dir_path ? File.join(relative_dir_path, name) : name
 
-            absolute_path = "#{absolute_dir_path}/#{name}"
+            absolute_path = File.join(absolute_dir_path, name)
             if File.directory?(absolute_path)
               next if ignored_dir_names&.include?(name) || ignored_abs_paths&.include?(absolute_path)
 
               if yield relative_path, absolute_path, true
-                walk(absolute_path, relative_path, &block)
+                walk(absolute_path, relative_path, ignored_abs_paths, ignored_dir_names, &block)
               end
             else
               yield relative_path, absolute_path, false

--- a/test/load_path_cache/store_test.rb
+++ b/test/load_path_cache/store_test.rb
@@ -107,20 +107,6 @@ module Bootsnap
           assert_nil Store.new(@path).get("a")
         end
       end
-
-      private
-
-      def stub_const(owner, const_name, stub_value)
-        original_value = owner.const_get(const_name)
-        owner.send(:remove_const, const_name)
-        owner.const_set(const_name, stub_value)
-        begin
-          yield
-        ensure
-          owner.send(:remove_const, const_name)
-          owner.const_set(const_name, original_value)
-        end
-      end
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -61,6 +61,18 @@ end
 
 module Minitest
   class Test
+    def stub_const(owner, const_name, stub_value)
+      original_value = owner.const_get(const_name)
+      owner.send(:remove_const, const_name)
+      owner.const_set(const_name, stub_value)
+      begin
+        yield
+      ensure
+        owner.send(:remove_const, const_name)
+        owner.const_set(const_name, original_value)
+      end
+    end
+
     module Help
       class << self
         def cache_path(dir, file, args_key = nil)


### PR DESCRIPTION
## Summary

Thanks for merging #526! While reviewing that fix and `PathScanner` in general, I noticed other behavioral differences between `ruby_call` and `native_call`, so I made the following fixes:

- Fix bug where `native_call` compared relative paths against absolute `BUNDLE_PATH` in nested directory scanning
- Extract common setup code from `ruby_call` and `native_call` into a shared `prepare_scan` helper method to minimize potential behavioral differences between the two
- Optimize `walk` to receive pre-partitioned ignored directories instead of recomputing on each recursive call
- Use consistent variable naming in both `ruby_call` and `native_call` so it's easier to compare the two implementations

## Problem

I noticed `native_call` had a bug in how it checks against `BUNDLE_PATH` here:
https://github.com/rails/bootsnap/blob/c2ef9a36c3ae67338e57aacd98d3399333ea0bc2/lib/bootsnap/load_path_cache/path_scanner.rb#L86-L91

After `dirs.map!`, `dir` is a relative path but `BUNDLE_PATH` is an absolute path, so the comparison will never match. In practice, the code often works because it skips entries starting with `.`, so `.bundle` will generally be skipped, but it would fail if `BUNDLE_PATH` is set to something like `/path/to/vendor/bundle` instead, which doesn't have a dot prefix.

This change fixes the code in `native_call` to compare against the absolute path instead and added a test that captures the case that would have failed in the original code.
