### PR TITLE
Fix ISeq.input_to_output to respect default external encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+* Fix encoding of Ruby source files loaded when `BOOTSNAP_READONLY` is set.
+  Files would incorectly be loaded in `ASCII-8BIT` causing literal strings outside
+  the pure ASCII range to have `ASCII-8BIT` encoding instead of `UTF-8`.
+  This bug was introduced in `1.24.0`.
+
 # 1.24.0
 
 * Added a hook API to customize Ruby compilation.

--- a/lib/bootsnap/compile_cache/iseq.rb
+++ b/lib/bootsnap/compile_cache/iseq.rb
@@ -66,7 +66,13 @@ module Bootsnap
         end
 
         def input_to_output(source, path, _kwargs)
-          RubyVM::InstructionSequence.compile(source, path, path, nil, @compile_options)
+          RubyVM::InstructionSequence.compile(
+            source.force_encoding(Encoding.default_external),
+            path,
+            path,
+            nil,
+            @compile_options,
+          )
         end
       end
 

--- a/test/compile_cache/iseq_cache_test.rb
+++ b/test/compile_cache/iseq_cache_test.rb
@@ -42,4 +42,11 @@ class CompileCacheISeqTest < Minitest::Test
   ensure
     Bootsnap::CompileCache::ISeq.compiler_selector = compiler_selector
   end
+
+  def test_input_to_output_encoding
+    compiler = Bootsnap::CompileCache::ISeq::DEFAULT
+    source = "_a = 'fée'.encoding".b
+    iseq = compiler.input_to_output(source, "a.rb", nil)
+    assert_equal Encoding.default_external, iseq.eval
+  end
 end


### PR DESCRIPTION
Fix: https://github.com/rails/bootsnap/issues/537

`ISeq.compile` uses the source string encoding, instead of `Encoding.default_external`, so we must change the string encoding.