### PR TITLE
Shrink the cache key from 64 to 32 bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,14 +237,15 @@ This may look worse at a glance, but underlies a large performance difference.
 useful. [This ruby patch](https://bugs.ruby-lang.org/issues/13378) optimizes them out when coupled
 with bootsnap.)*
 
-Bootsnap writes a cache file containing a 64 byte header followed by the cache contents. The header
+Bootsnap writes a cache file containing a 48 byte header followed by the cache contents. The header
 is a cache key including several fields:
 
-* `version`, hardcoded in bootsnap. Essentially a schema version;
-* `ruby_platform`, A hash of `RUBY_PLATFORM` (e.g. x86_64-linux-gnu) variable.
+* `ruby_version_digest`, a digest of:
+  * The `RUBY_DESCRIPTION` constant e.g. `"ruby 4.0.2 (2026-03-17 revision d3da9fec82) +PRISM [arm64-darwin25]"`.
+  * Bootsnap's cache version. Hardcoded in bootsnap. Essentially a schema version;
 * `compile_option`, which changes with `RubyVM::InstructionSequence.compile_option` does;
-* `ruby_revision`, A hash of `RUBY_REVISION`, the exact version of Ruby;
 * `size`, the size of the source file;
+* `digest`, a fnv1a_64 hash of the source file;
 * `mtime`, the last-modification timestamp of the source file when it was compiled; and
 * `data_size`, the number of bytes following the header, which we need to read it into a buffer.
 

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ is a cache key including several fields:
 * `ruby_version_digest`, a digest of:
   * The `RUBY_DESCRIPTION` constant e.g. `"ruby 4.0.2 (2026-03-17 revision d3da9fec82) +PRISM [arm64-darwin25]"`.
   * Bootsnap's cache version. Hardcoded in bootsnap. Essentially a schema version;
-* `compile_option`, which changes with `RubyVM::InstructionSequence.compile_option` does;
+  * The content of `RubyVM::InstructionSequence.compile_option`.
 * `size`, the size of the source file;
 * `digest`, a fnv1a_64 hash of the source file;
 * `mtime`, the last-modification timestamp of the source file when it was compiled; and

--- a/ext/bootsnap/bootsnap.c
+++ b/ext/bootsnap/bootsnap.c
@@ -40,7 +40,7 @@
 #define MAX_CACHEPATH_SIZE 1000
 #define MAX_CACHEDIR_SIZE  981
 
-#define KEY_SIZE 40
+#define KEY_SIZE 32
 
 #define MAX_CREATE_TEMPFILE_ATTEMPT 3
 
@@ -62,10 +62,10 @@
  */
 struct bs_cache_key {
   uint64_t ruby_version_digest;
-  uint64_t size;
   uint64_t mtime;
-  uint64_t data_size;
   uint64_t digest;
+  uint32_t size;
+  uint32_t data_size;
 } __attribute__((packed));
 
 /*
@@ -556,9 +556,18 @@ open_current_file(const char * path, struct bs_cache_key * key, const char ** er
   }
 
   key->ruby_version_digest = current_ruby_version_digest;
-  key->size           = (uint64_t)statbuf.st_size;
-  key->mtime          = (uint64_t)statbuf.st_mtime;
-  key->digest         = 0;
+
+  // We're limited to file of 4GiB or less. Hopefully that's enough for everyone.
+  if (statbuf.st_size > (uint32_t)-1) {
+    *errno_provenance = "bs_fetch:open_current_file:file_too_big";
+    close(fd);
+    errno = EFBIG;
+    return -1;
+  }
+
+  key->size = (uint32_t)statbuf.st_size;
+  key->mtime = (uint64_t)statbuf.st_mtime;
+  key->digest = 0;
 
   return fd;
 }
@@ -747,7 +756,12 @@ atomic_write_cache_file(char * path, struct bs_cache_key * key, VALUE data, cons
   setmode(fd, O_BINARY);
   #endif
 
-  key->data_size = RSTRING_LEN(data);
+  uint64_t data_size = RSTRING_LEN(data);
+  if (data_size > (uint32_t)-1) {
+    return 0; // Don't cache.
+  }
+
+  key->data_size = (uint32_t)data_size;
   nwrite = write(fd, key, KEY_SIZE);
   if (nwrite < 0) {
     *errno_provenance = "bs_fetch:atomic_write_cache_file:write";

--- a/ext/bootsnap/bootsnap.c
+++ b/ext/bootsnap/bootsnap.c
@@ -40,7 +40,7 @@
 #define MAX_CACHEPATH_SIZE 1000
 #define MAX_CACHEDIR_SIZE  981
 
-#define KEY_SIZE 64
+#define KEY_SIZE 48
 
 #define MAX_CREATE_TEMPFILE_ATTEMPT 3
 
@@ -49,34 +49,29 @@
 #endif
 
 /*
- * An instance of this key is written as the first 64 bytes of each cache file.
+ * An instance of this key is written as the first `KEY_SIZE` bytes of each cache file.
  * The mtime and size members track whether the file contents have changed, and
- * the version, ruby_platform, compile_option, and ruby_revision members track
- * changes to the environment that could invalidate compile results without
+ * the ruby_version_digest (bootsnap_cache_version + RUBY_DESCRIPTION) and compile_option
+ * members track changes to the environment that could invalidate compile results without
  * file contents having changed. The data_size member is not truly part of the
  * "key". Really, this could be called a "header" with the first six members
  * being an embedded "key" struct and an additional data_size member.
  *
  * The data_size indicates the remaining number of bytes in the cache file
  * after the header (the size of the cached artifact).
- *
- * After data_size, the struct is padded to 64 bytes.
  */
 struct bs_cache_key {
-  uint32_t version;
-  uint32_t ruby_platform;
-  uint32_t compile_option;
-  uint32_t ruby_revision;
+  uint64_t ruby_version_digest;
   uint64_t size;
   uint64_t mtime;
-  uint64_t data_size; //
+  uint64_t data_size;
   uint64_t digest;
-  uint8_t digest_set;
-  uint8_t pad[15];
+  uint32_t compile_option;
+  uint32_t digest_set; // boolean but serves as padding
 } __attribute__((packed));
 
 /*
- * If the struct padding isn't correct to pad the key to 64 bytes, refuse to
+ * If the struct padding isn't correct to pad the key to `KEY_SIZE` bytes, refuse to
  * compile.
  */
 #define STATIC_ASSERT(X)            STATIC_ASSERT2(X,__LINE__)
@@ -86,15 +81,14 @@ struct bs_cache_key {
 STATIC_ASSERT(sizeof(struct bs_cache_key) == KEY_SIZE);
 
 /* Effectively a schema version. Bumping invalidates all previous caches */
-static const uint32_t current_version = 6;
+static const uint32_t bootsnap_cache_version = 7;
 
-/* hash of e.g. "x86_64-darwin17", invalidating when ruby is recompiled on a
- * new OS ABI, etc. */
-static uint32_t current_ruby_platform;
-/* Invalidates cache when switching ruby versions */
-static uint32_t current_ruby_revision;
+/* Invalidates cache when switching ruby version, platform or ABI */
+static uint64_t current_ruby_version_digest = 0;
+
 /* Invalidates cache when RubyVM::InstructionSequence.compile_option changes */
 static uint32_t current_compile_option_crc32 = 0;
+
 /* Current umask */
 static mode_t current_umask;
 
@@ -136,8 +130,7 @@ static VALUE bs_fetch(char * path, VALUE path_v, char * cache_path, VALUE handle
 static VALUE bs_precompile(char * path, VALUE path_v, char * cache_path, VALUE handler);
 static int open_current_file(const char * path, struct bs_cache_key * key, const char ** errno_provenance);
 static int fetch_cached_data(int fd, ssize_t data_size, VALUE handler, VALUE args, VALUE * output_data, int * exception_tag, const char ** errno_provenance);
-static uint32_t get_ruby_revision(void);
-static uint32_t get_ruby_platform(void);
+static uint64_t get_ruby_version_digest(void);
 
 /*
  * Helper functions to call ruby methods on handler object without crashing on
@@ -295,8 +288,7 @@ Init_bootsnap(void)
   rb_cBootsnap_CompileCache_UNCOMPILABLE = rb_const_get(rb_mBootsnap_CompileCache, rb_intern("UNCOMPILABLE"));
   rb_global_variable(&rb_cBootsnap_CompileCache_UNCOMPILABLE);
 
-  current_ruby_revision = get_ruby_revision();
-  current_ruby_platform = get_ruby_platform();
+  current_ruby_version_digest = get_ruby_version_digest();
 
   instrumentation_method = rb_intern("_instrument");
 
@@ -363,10 +355,9 @@ bs_compile_option_crc32_set(VALUE self, VALUE crc32_v)
 }
 
 static uint64_t
-fnv1a_64_iter(uint64_t h, const VALUE str)
+fnv1a_64_iter(uint64_t h, const unsigned char *s, size_t len)
 {
-  unsigned char *s = (unsigned char *)RSTRING_PTR(str);
-  unsigned char *str_end = (unsigned char *)RSTRING_PTR(str) + RSTRING_LEN(str);
+  const unsigned char *str_end = s + len;
 
   while (s < str_end) {
     h ^= (uint64_t)*s++;
@@ -377,45 +368,25 @@ fnv1a_64_iter(uint64_t h, const VALUE str)
 }
 
 static uint64_t
-fnv1a_64(const VALUE str)
+fnv1a_64_iter_str(uint64_t h, const VALUE str)
+{
+  Check_Type(str, T_STRING);
+  return fnv1a_64_iter(h, (unsigned char *)RSTRING_PTR(str), RSTRING_LEN(str));
+}
+
+static uint64_t
+fnv1a_64_str(const VALUE str)
 {
   uint64_t h = (uint64_t)0xcbf29ce484222325ULL;
-  return fnv1a_64_iter(h, str);
+  return fnv1a_64_iter_str(h, str);
 }
 
-/*
- * Ruby's revision may be Integer or String. CRuby 2.7 or later uses
- * Git commit ID as revision. It's String.
- */
-static uint32_t
-get_ruby_revision(void)
+static uint64_t
+get_ruby_version_digest(void)
 {
-  VALUE ruby_revision;
-
-  ruby_revision = rb_const_get(rb_cObject, rb_intern("RUBY_REVISION"));
-  if (RB_TYPE_P(ruby_revision, RUBY_T_FIXNUM)) {
-    return FIX2INT(ruby_revision);
-  } else {
-    uint64_t hash;
-
-    hash = fnv1a_64(ruby_revision);
-    return (uint32_t)(hash >> 32);
-  }
-}
-
-/*
- * When ruby's version doesn't change, but it's recompiled on a different OS
- * (or OS version), we need to invalidate the cache.
- */
-static uint32_t
-get_ruby_platform(void)
-{
-  uint64_t hash;
-  VALUE ruby_platform;
-
-  ruby_platform = rb_const_get(rb_cObject, rb_intern("RUBY_PLATFORM"));
-  hash = fnv1a_64(ruby_platform);
-  return (uint32_t)(hash >> 32);
+  uint64_t hash = fnv1a_64_str(rb_const_get(rb_cObject, rb_intern("RUBY_DESCRIPTION")));
+  hash = fnv1a_64_iter(hash, (unsigned char *)&bootsnap_cache_version, sizeof(bootsnap_cache_version));
+  return hash;
 }
 
 /*
@@ -443,7 +414,7 @@ bs_cache_path(VALUE cachedir_v, VALUE namespace_v, VALUE path_v, char (* cache_p
   const char * cachedir = RSTRING_PTR(cachedir_v);
   const char * namespace = NIL_P(namespace_v) ? "" : RSTRING_PTR(namespace_v);
 
-  uint64_t hash = fnv1a_64(path_v);
+  uint64_t hash = fnv1a_64_str(path_v);
   uint8_t first_byte = (hash >> (64 - 8));
   uint64_t remainder = hash & 0x00ffffffffffffff;
 
@@ -460,10 +431,9 @@ bs_cache_path(VALUE cachedir_v, VALUE namespace_v, VALUE path_v, char (* cache_p
  */
 static enum cache_status cache_key_equal_fast_path(struct bs_cache_key *k1,
                                      struct bs_cache_key *k2) {
-  if (k1->version == k2->version &&
-          k1->ruby_platform == k2->ruby_platform &&
+  if (k1->ruby_version_digest == k2->ruby_version_digest &&
           k1->compile_option == k2->compile_option &&
-          k1->ruby_revision == k2->ruby_revision && k1->size == k2->size) {
+          k1->size == k2->size) {
       if (k1->mtime == k2->mtime) {
         return hit;
       }
@@ -509,7 +479,7 @@ static void bs_cache_key_digest(struct bs_cache_key *key,
                                 const VALUE input_data) {
   if (key->digest_set)
     return;
-  key->digest = fnv1a_64(input_data);
+  key->digest = fnv1a_64_str(input_data);
   key->digest_set = 1;
 }
 
@@ -587,12 +557,11 @@ open_current_file(const char * path, struct bs_cache_key * key, const char ** er
     return -1;
   }
 
-  key->version        = current_version;
-  key->ruby_platform  = current_ruby_platform;
+  key->ruby_version_digest = current_ruby_version_digest;
   key->compile_option = current_compile_option_crc32;
-  key->ruby_revision  = current_ruby_revision;
   key->size           = (uint64_t)statbuf.st_size;
   key->mtime          = (uint64_t)statbuf.st_mtime;
+  key->digest         = 0;
   key->digest_set     = false;
 
   return fd;
@@ -663,10 +632,10 @@ open_cache_file(const char * path, struct bs_cache_key * key, const char ** errn
 
 /*
  * The cache file is laid out like:
- *   0...64 : bs_cache_key
- *   64..-1 : cached artifact
+ *   0...`KEY_SIZE` : bs_cache_key
+ *   `KEY_SIZE`..-1 : cached artifact
  *
- * This function takes a file descriptor whose position is pre-set to 64, and
+ * This function takes a file descriptor whose position is pre-set to `KEY_SIZE`, and
  * the data_size (corresponding to the remaining number of bytes) listed in the
  * cache header.
  *

--- a/ext/bootsnap/bootsnap.c
+++ b/ext/bootsnap/bootsnap.c
@@ -40,7 +40,7 @@
 #define MAX_CACHEPATH_SIZE 1000
 #define MAX_CACHEDIR_SIZE  981
 
-#define KEY_SIZE 48
+#define KEY_SIZE 40
 
 #define MAX_CREATE_TEMPFILE_ATTEMPT 3
 
@@ -66,8 +66,6 @@ struct bs_cache_key {
   uint64_t mtime;
   uint64_t data_size;
   uint64_t digest;
-  uint32_t compile_option;
-  uint32_t digest_set; // boolean but serves as padding
 } __attribute__((packed));
 
 /*
@@ -84,10 +82,11 @@ STATIC_ASSERT(sizeof(struct bs_cache_key) == KEY_SIZE);
 static const uint32_t bootsnap_cache_version = 7;
 
 /* Invalidates cache when switching ruby version, platform or ABI */
-static uint64_t current_ruby_version_digest = 0;
+static uint64_t base_ruby_version_digest = 0;
 
-/* Invalidates cache when RubyVM::InstructionSequence.compile_option changes */
-static uint32_t current_compile_option_crc32 = 0;
+// `base_ruby_version_digest` combined with RubyVM::InstructionSequence.compile_option
+// Invalidates cache when RubyVM::InstructionSequence.compile_option changes
+static uint64_t current_ruby_version_digest = 0;
 
 /* Current umask */
 static mode_t current_umask;
@@ -288,7 +287,7 @@ Init_bootsnap(void)
   rb_cBootsnap_CompileCache_UNCOMPILABLE = rb_const_get(rb_mBootsnap_CompileCache, rb_intern("UNCOMPILABLE"));
   rb_global_variable(&rb_cBootsnap_CompileCache_UNCOMPILABLE);
 
-  current_ruby_version_digest = get_ruby_version_digest();
+  base_ruby_version_digest = get_ruby_version_digest();
 
   instrumentation_method = rb_intern("_instrument");
 
@@ -337,23 +336,6 @@ bs_revalidation_set(VALUE self, VALUE enabled)
   return enabled;
 }
 
-/*
- * Bootsnap's ruby code registers a hook that notifies us via this function
- * when compile_option changes. These changes invalidate all existing caches.
- *
- * Note that on 32-bit platforms, a CRC32 can't be represented in a Fixnum, but
- * can be represented by a uint.
- */
-static VALUE
-bs_compile_option_crc32_set(VALUE self, VALUE crc32_v)
-{
-  if (!RB_TYPE_P(crc32_v, T_BIGNUM) && !RB_TYPE_P(crc32_v, T_FIXNUM)) {
-    Check_Type(crc32_v, T_FIXNUM);
-  }
-  current_compile_option_crc32 = NUM2UINT(crc32_v);
-  return Qnil;
-}
-
 static uint64_t
 fnv1a_64_iter(uint64_t h, const unsigned char *s, size_t len)
 {
@@ -379,6 +361,24 @@ fnv1a_64_str(const VALUE str)
 {
   uint64_t h = (uint64_t)0xcbf29ce484222325ULL;
   return fnv1a_64_iter_str(h, str);
+}
+
+/*
+ * Bootsnap's ruby code registers a hook that notifies us via this function
+ * when compile_option changes. These changes invalidate all existing caches.
+ *
+ * Note that on 32-bit platforms, a CRC32 can't be represented in a Fixnum, but
+ * can be represented by a uint.
+ */
+static VALUE
+bs_compile_option_crc32_set(VALUE self, VALUE crc32_v)
+{
+  if (!RB_TYPE_P(crc32_v, T_BIGNUM) && !RB_TYPE_P(crc32_v, T_FIXNUM)) {
+    Check_Type(crc32_v, T_FIXNUM);
+  }
+  uint32_t crc32 = (uint32_t)NUM2UINT(crc32_v);
+  current_ruby_version_digest = fnv1a_64_iter(base_ruby_version_digest, (unsigned char *)&crc32, sizeof(crc32));
+  return Qnil;
 }
 
 static uint64_t
@@ -432,7 +432,6 @@ bs_cache_path(VALUE cachedir_v, VALUE namespace_v, VALUE path_v, char (* cache_p
 static enum cache_status cache_key_equal_fast_path(struct bs_cache_key *k1,
                                      struct bs_cache_key *k2) {
   if (k1->ruby_version_digest == k2->ruby_version_digest &&
-          k1->compile_option == k2->compile_option &&
           k1->size == k2->size) {
       if (k1->mtime == k2->mtime) {
         return hit;
@@ -477,10 +476,9 @@ static int update_cache_key(struct bs_cache_key *current_key, struct bs_cache_ke
  */
 static void bs_cache_key_digest(struct bs_cache_key *key,
                                 const VALUE input_data) {
-  if (key->digest_set)
+  if (key->digest)
     return;
   key->digest = fnv1a_64_str(input_data);
-  key->digest_set = 1;
 }
 
 /*
@@ -558,11 +556,9 @@ open_current_file(const char * path, struct bs_cache_key * key, const char ** er
   }
 
   key->ruby_version_digest = current_ruby_version_digest;
-  key->compile_option = current_compile_option_crc32;
   key->size           = (uint64_t)statbuf.st_size;
   key->mtime          = (uint64_t)statbuf.st_mtime;
   key->digest         = 0;
-  key->digest_set     = false;
 
   return fd;
 }

--- a/test/compile_cache_key_format_test.rb
+++ b/test/compile_cache_key_format_test.rb
@@ -11,24 +11,19 @@ class CompileCacheKeyFormatTest < Minitest::Test
   include TmpdirHelper
 
   R = {
-    version: 0...4,
-    ruby_platform: 4...8,
-    compile_option: 8...12,
-    ruby_revision: 12...16,
-    size: 16...24,
-    mtime: 24...32,
-    data_size: 32...40,
+    ruby_version_digest: 0...8,
+    size: 8...16,
+    mtime: 16...24,
+    data_size: 24...32,
+    digest: 32...40,
+    compile_option: 40...44,
+    digest_set: 44...48,
   }.freeze
+  CACHE_KEY_SIZE = 48
 
   def teardown
     Bootsnap::CompileCache::Native.revalidation = false
     super
-  end
-
-  def test_key_version
-    key = cache_key_for_file(FILE)
-    exp = [6].pack("L")
-    assert_equal(exp, key[R[:version]])
   end
 
   def test_key_compile_option_stable
@@ -42,14 +37,11 @@ class CompileCacheKeyFormatTest < Minitest::Test
     RubyVM::InstructionSequence.compile_option = {tailcall_optimization: false}
   end
 
-  def test_key_ruby_revision
+  def test_key_ruby_version_digest
     key = cache_key_for_file(FILE)
-    exp = if RUBY_REVISION.is_a?(String)
-      [Help.fnv1a_64(RUBY_REVISION) >> 32].pack("L")
-    else
-      [RUBY_REVISION].pack("L")
-    end
-    assert_equal(exp, key[R[:ruby_revision]])
+    hash = Help.fnv1a_64(RUBY_DESCRIPTION)
+    hash = Help.fnv1a_64_iter(hash, [7].pack("L"))
+    assert_equal([hash].pack("Q"), key[R[:ruby_version_digest]])
   end
 
   def test_key_size
@@ -78,7 +70,7 @@ class CompileCacheKeyFormatTest < Minitest::Test
     cache_file = entries.first
 
     data = File.read(cache_file)
-    assert_equal("neato #{target}", data.force_encoding(Encoding::BINARY)[64..])
+    assert_equal("neato #{target}", data.b[CACHE_KEY_SIZE..])
 
     actual = Bootsnap::CompileCache::Native.fetch(cache_dir, nil, target, TestHandler, nil)
     assert_equal("NEATO #{target.upcase}", actual)
@@ -111,6 +103,6 @@ class CompileCacheKeyFormatTest < Minitest::Test
   def cache_key_for_file(file)
     Bootsnap::CompileCache::Native.fetch(@tmp_dir, nil, file, TestHandler, nil)
     data = File.binread(Help.cache_path(@tmp_dir, file))
-    data.byteslice(0..31)
+    data.byteslice(0...CACHE_KEY_SIZE)
   end
 end

--- a/test/compile_cache_key_format_test.rb
+++ b/test/compile_cache_key_format_test.rb
@@ -12,12 +12,12 @@ class CompileCacheKeyFormatTest < Minitest::Test
 
   R = {
     ruby_version_digest: 0...8,
-    size: 8...16,
-    mtime: 16...24,
-    data_size: 24...32,
-    digest: 32...40,
+    mtime: 8...16,
+    digest: 16...24,
+    size: 24...28,
+    data_size: 28...32,
   }.freeze
-  CACHE_KEY_SIZE = 40
+  CACHE_KEY_SIZE = 32
 
   def teardown
     Bootsnap::CompileCache::Native.revalidation = false
@@ -48,7 +48,7 @@ class CompileCacheKeyFormatTest < Minitest::Test
   def test_key_size
     key = cache_key_for_file(FILE)
     exp = File.size(FILE)
-    act = key[R[:size]].unpack1("Q")
+    act = key[R[:size]].unpack1("L")
     assert_equal(exp, act)
   end
 

--- a/test/compile_cache_key_format_test.rb
+++ b/test/compile_cache_key_format_test.rb
@@ -16,10 +16,8 @@ class CompileCacheKeyFormatTest < Minitest::Test
     mtime: 16...24,
     data_size: 24...32,
     digest: 32...40,
-    compile_option: 40...44,
-    digest_set: 44...48,
   }.freeze
-  CACHE_KEY_SIZE = 48
+  CACHE_KEY_SIZE = 40
 
   def teardown
     Bootsnap::CompileCache::Native.revalidation = false
@@ -31,16 +29,19 @@ class CompileCacheKeyFormatTest < Minitest::Test
     k2 = cache_key_for_file(FILE)
     RubyVM::InstructionSequence.compile_option = {tailcall_optimization: true}
     k3 = cache_key_for_file(FILE)
-    assert_equal(k1[R[:compile_option]], k2[R[:compile_option]])
-    refute_equal(k1[R[:compile_option]], k3[R[:compile_option]])
+    assert_equal(k1[R[:ruby_version_digest]], k2[R[:ruby_version_digest]])
+    refute_equal(k1[R[:ruby_version_digest]], k3[R[:ruby_version_digest]])
   ensure
     RubyVM::InstructionSequence.compile_option = {tailcall_optimization: false}
   end
 
   def test_key_ruby_version_digest
+    Bootsnap::CompileCache::ISeq.compile_option_updated
+
     key = cache_key_for_file(FILE)
     hash = Help.fnv1a_64(RUBY_DESCRIPTION)
     hash = Help.fnv1a_64_iter(hash, [7].pack("L"))
+    hash = Help.fnv1a_64_iter(hash, [Zlib.crc32(RubyVM::InstructionSequence.compile_option.inspect)].pack("L"))
     assert_equal([hash].pack("Q"), key[R[:ruby_version_digest]])
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -85,13 +85,16 @@ module Minitest
           "#{dir}/#{hex[0..1]}/#{hex[2..]}"
         end
 
-        def fnv1a_64(data)
-          hash = 0xcbf29ce484222325
+        def fnv1a_64_iter(hash, data)
           data.bytes.each do |byte|
             hash ^= byte
             hash = (hash * 0x100000001b3) % (2**64)
           end
           hash
+        end
+
+        def fnv1a_64(data)
+          fnv1a_64_iter(0xcbf29ce484222325, data)
         end
 
         def set_file(path, contents, mtime = nil)


### PR DESCRIPTION
Also get rid of all padding bytes, ensuring cache keys don't contain any semi-random bytes.

Fix: https://github.com/rails/bootsnap/issues/542

FYI: @justinlocsei 