### PR TITLE
Use the latest header size in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ This may look worse at a glance, but underlies a large performance difference.
 useful. [This ruby patch](https://bugs.ruby-lang.org/issues/13378) optimizes them out when coupled
 with bootsnap.)*
 
-Bootsnap writes a cache file containing a 48 byte header followed by the cache contents. The header
+Bootsnap writes a cache file containing a 32 byte header followed by the cache contents. The header
 is a cache key including several fields:
 
 * `ruby_version_digest`, a digest of:


### PR DESCRIPTION
Since you pushed [further](https://github.com/rails/bootsnap/commit/85d74046cca8e8f3461a17d28d1a8dd4e94acef5) [optimizations](https://github.com/rails/bootsnap/commit/2ca940864e27c9bc49512320825f733f27da2584) to the size of the header, this PR just updates the documentation to reflect the new size.