### PR TITLE
Handle RuntimeError from to_binary when Coverage is running

### DIFF
--- a/lib/bootsnap/compile_cache/iseq.rb
+++ b/lib/bootsnap/compile_cache/iseq.rb
@@ -25,6 +25,9 @@ module Bootsnap
         false
       rescue TypeError
         true
+      rescue RuntimeError => error # Ref: https://github.com/rails/bootsnap/issues/547
+        raise unless error.message == "should not compile with coverage"
+        false
       end
 
       if has_ruby_bug_18250
@@ -46,6 +49,9 @@ module Bootsnap
           RubyVM::InstructionSequence.compile_file(path).to_binary
         rescue SyntaxError
           UNCOMPILABLE # syntax error
+        rescue RuntimeError => error # Ref: https://github.com/rails/bootsnap/issues/547
+          raise unless error.message == "should not compile with coverage"
+          UNCOMPILABLE
         end
       end
 


### PR DESCRIPTION
## Summary

Handle `RuntimeError: "should not compile with coverage"` raised by `RubyVM::InstructionSequence#to_binary` on Ruby 4.0.4+.

Fixes #547

## Background

Ruby 4.0.4 backported the fix for [Bug #22018](https://bugs.ruby-lang.org/issues/22018) ([ruby/ruby#16846](https://github.com/ruby/ruby/pull/16846), which makes `to_binary` raise a `RuntimeError` when Coverage is running to prevent silent loss of coverage data.

Bootsnap's `has_ruby_bug_18250` detection calls `to_binary` during module evaluation and only rescued `TypeError`, causing a crash when Coverage is active.

## Changes

* `has_ruby_bug_18250` detection: rescue `RuntimeError` and return `false` when the message is `"should not compile with coverage"` (it's not bug #18250, just coverage interference)
* `input_to_storage`: rescue `RuntimeError` with the same message check and return `UNCOMPILABLE`

Unrelated `RuntimeError`s are re-raised.

## Impact

* Ruby <= 4.0.3: No behavior change (the `RuntimeError` is never raised)
* Ruby >= 4.0.4: Fixes the crash when Coverage is running at boot time

---

Thank you as always for maintaining this great gem!