### PR TITLE
Make `Bootsnap.enable_frozen_string_literal` work even with coverage on

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,10 @@ Bootsnap::CompileCache::ISeq.compiler_selector = ->(path) do
 end
 ```
 
+*Important note*: This feature is only fully supported by Ruby `4.0.4` and newer.
+On older rubies the feature work except if the `Coverage` module is enabled, in which case a warning will be emitted
+and the default Ruby compiler will be used.
+
 ## Precompilation
 
 In development environments the bootsnap compilation cache is generated on the fly when source files are loaded.

--- a/lib/bootsnap/compile_cache/iseq.rb
+++ b/lib/bootsnap/compile_cache/iseq.rb
@@ -108,11 +108,30 @@ module Bootsnap
 
       DEFAULT = Compiler.new
       FROZEN_STRING_LITERAL = Compiler.new("-fstr", {frozen_string_literal: true}.freeze)
-      MUTABLE_STRING_LITERAL = Compiler.new("-no-fstr", {frozen_string_literal: false}.freeze)
+      COVERAGE_SUPPORTED = RUBY_VERSION >= "4.0.4"
       @default_compiler = DEFAULT
+      @coverage_support_warning_emitted = false
 
       def self.fetch(path, cache_dir: ISeq.cache_dir)
         compiler = compiler_selector&.call(path) || default_compiler
+
+        # Having coverage enabled prevents iseq dumping/loading.
+        if coverage_on?
+          return nil if compiler.equal?(DEFAULT)
+
+          if COVERAGE_SUPPORTED
+            return compiler.input_to_output(File.read(path.to_s), path.to_s, nil)
+          elsif !@coverage_support_warning_emitted
+            @coverage_support_warning_emitted = true
+            warn(<<~MSG)
+              Using `Bootsnap.enable_frozen_string_literal` with code coverage enabled is only supported on Ruby 4.0.4+.
+              Files loaded while coverage is on, will have mutable string literals.
+            MSG
+          end
+
+          return nil
+        end
+
         Bootsnap::CompileCache::Native.fetch(
           cache_dir,
           compiler.namespace,
@@ -132,11 +151,18 @@ module Bootsnap
         )
       end
 
+      if RUBY_VERSION < "3.1."
+        def self.coverage_on?
+          defined?(Coverage) && Coverage.running?
+        end
+      else
+        def self.coverage_on?
+          defined?(Coverage) && Coverage.state != :idle
+        end
+      end
+
       module InstructionSequenceMixin
         def load_iseq(path)
-          # Having coverage enabled prevents iseq dumping/loading.
-          return nil if coverage_on?
-
           Bootsnap::CompileCache::ISeq.fetch(path.to_s)
         rescue RuntimeError => error
           if error.message.include?("unmatched platform")
@@ -148,16 +174,6 @@ module Bootsnap
         def compile_option=(hash)
           super
           Bootsnap::CompileCache::ISeq.compile_option_updated
-        end
-
-        if RUBY_VERSION < "3.1."
-          def coverage_on?
-            defined?(Coverage) && Coverage.running?
-          end
-        else
-          def coverage_on?
-            defined?(Coverage) && Coverage.state != :idle
-          end
         end
       end
 

--- a/test/compile_cache/iseq_cache_test.rb
+++ b/test/compile_cache/iseq_cache_test.rb
@@ -24,7 +24,7 @@ class CompileCacheISeqTest < Minitest::Test
       if path.end_with?("a.rb")
         Bootsnap::CompileCache::ISeq::FROZEN_STRING_LITERAL
       else
-        Bootsnap::CompileCache::ISeq::MUTABLE_STRING_LITERAL
+        Bootsnap::CompileCache::ISeq::DEFAULT
       end
     }
 

--- a/test/compile_cache_test.rb
+++ b/test/compile_cache_test.rb
@@ -23,7 +23,6 @@ class CompileCacheTest < Minitest::Test
 
   def test_coverage_running
     require "coverage"
-    Bootsnap::CompileCache::ISeq.expects(:fetch).times(0)
     begin
       Coverage.start
       path = Help.set_file("a.rb", "a = a = 3", 100)

--- a/test/fixtures/app/boot.rb
+++ b/test/fixtures/app/boot.rb
@@ -21,7 +21,7 @@ require "bootsnap/setup"
 
 case ENV["COMPILER"]
 when "fstr"
-  Bootsnap.enable_frozen_string_literal(app_only: false)
+  Bootsnap.enable_frozen_string_literal(app_only: true)
 when nil
 else
   raise "Unkown $COMPILER value: #{ENV["COMPILER"].inspect}"

--- a/test/fixtures/app/lib/coverage_accurate.rb
+++ b/test/fixtures/app/lib/coverage_accurate.rb
@@ -1,0 +1,29 @@
+require "coverage"
+Coverage.start
+require "coverage_test"
+
+actual = Coverage.result
+fstr_check = 0
+mstr_check = 0
+
+case ENV["CHECK_STRING_LITERALS"]
+when "frozen"
+  fstr_check = 1
+when "mutable"
+  mstr_check = 1
+end
+
+coverage = [1, nil, fstr_check, nil, mstr_check, nil, nil, 0, nil, nil, 1, 1, nil, nil, 1, 1, nil, nil, 1]
+expected = {
+  File.expand_path("../coverage_test.rb", __FILE__) => coverage,
+}
+
+if actual == expected
+  puts "OK: #{actual.inspect}"
+else
+  puts <<~EOS
+    Expected: #{expected.inspect}
+    Actual:   #{actual.inspect}
+  EOS
+  exit 1
+end

--- a/test/fixtures/app/lib/coverage_test.rb
+++ b/test/fixtures/app/lib/coverage_test.rb
@@ -1,0 +1,19 @@
+case ENV["CHECK_STRING_LITERALS"]
+when "frozen"
+  raise "String literal should have been frozen" unless "test".frozen?
+when "mutable"
+  raise "String literal should NOT have been frozen" if "test".frozen?
+when nil
+else
+  raise "Unexpected value for $CHECK_STRING_LITERALS: #{ENV["CHECK_STRING_LITERALS"].inspect}"
+end
+
+def method_a
+  1 + 1
+end
+
+def method_b
+  method_a + 2
+end
+
+method_b

--- a/test/integration/app_boot_test.rb
+++ b/test/integration/app_boot_test.rb
@@ -28,22 +28,32 @@ module Bootsnap
       assert_boot("check_frozen_literal", compiler: "fstr")
     end
 
-    def test_boot_frozen_string_literal_and_coverage
+    def test_coverage_working
       skip("MRI only") unless RUBY_ENGINE == "ruby"
-      skip("Need to find a workaround for this...")
-      assert_boot("check_frozen_literal", compiler: "fstr", coverage: "started")
+      assert_boot("coverage_accurate")
+    end
+
+    def test_coverage_working_with_frozen_string_literal
+      skip("MRI only") unless RUBY_ENGINE == "ruby"
+      working = RUBY_VERSION >= "4.0.4"
+      assert_boot("coverage_accurate", compiler: "fstr", check_string_literals: working ? "frozen" : "mutable")
     end
 
     private
 
-    def assert_boot(feature, coverage: nil, compiler: nil)
+    def assert_boot(feature, coverage: nil, compiler: nil, check_string_literals: nil)
       env = {
         "BOOTSNAP_CACHE_DIR" => @tmp_dir,
         "FEATURE" => feature,
         "COVERAGE" => coverage,
         "COMPILER" => compiler,
+        "CHECK_STRING_LITERALS" => check_string_literals,
       }
-      stdin, stdout_and_stderr, wait_thread = Open3.popen2e(env, RbConfig.ruby, File.join(APP_DIR, "boot.rb"))
+      stdin, stdout_and_stderr, wait_thread = Open3.popen2e(
+        env,
+        RbConfig.ruby, File.join(APP_DIR, "boot.rb"),
+        chdir: APP_DIR
+      )
       stdin.close
       status = wait_thread.value
       assert_predicate status, :success?, stdout_and_stderr.read


### PR DESCRIPTION
Fix `enable_frozen_string_literal` support with coverage enabled
    
Only possible on Ruby `4.0.4+`