### PR TITLE
Better support `RubyVM::ISeq.compile_option` being mutated

### DIFF
--- a/lib/bootsnap.rb
+++ b/lib/bootsnap.rb
@@ -102,8 +102,8 @@ module Bootsnap
           end
         }
       else
-        Bootsnap::CompileCache::ISeq.compiler_selector = nil
-        Bootsnap::CompileCache::ISeq.default_compiler = Bootsnap::CompileCache::ISeq::FROZEN_STRING_LITERAL
+        options = RubyVM::InstructionSequence.compile_option.merge(frozen_string_literal: true)
+        RubyVM::InstructionSequence.compile_option = options
       end
     end
 

--- a/lib/bootsnap/compile_cache/iseq.rb
+++ b/lib/bootsnap/compile_cache/iseq.rb
@@ -19,180 +19,207 @@ module Bootsnap
         end
       end
 
-      class Compiler
-        attr_reader :namespace, :compile_options
+      if supported?
+        class Compiler
+          attr_reader :namespace
 
-        def initialize(namespace = nil, compile_options = nil)
-          @namespace = namespace
-          @compile_options = compile_options
-        end
-
-        has_ruby_bug_18250 = RUBY_VERSION.start_with?("3.0.") && begin # https://bugs.ruby-lang.org/issues/18250
-          if defined? RubyVM::InstructionSequence
-            RubyVM::InstructionSequence.compile("def foo(*); ->{ super }; end; def foo(**); ->{ super }; end").to_binary
+          def initialize(namespace = nil, compile_options = nil)
+            @namespace = namespace
+            @options = compile_options.freeze
+            update_options
           end
-          false
-        rescue TypeError
-          true
-        end
 
-        has_ruby_bug_22023 = if defined?(RubyVM::InstructionSequence) && RubyVM::InstructionSequence.respond_to?(:compile_file_prism)
-          begin
-            RubyVM::InstructionSequence.compile_file(File.expand_path("../ruby_bug_22023_canary.rb", __FILE__))
+          def update_options
+            @compile_options = if @options.nil? || @options < RubyVM::InstructionSequence.compile_option
+              nil
+            else
+              RubyVM::InstructionSequence.compile_option.merge(@options).freeze
+            end
+          end
+
+          has_ruby_bug_18250 = RUBY_VERSION.start_with?("3.0.") && begin # https://bugs.ruby-lang.org/issues/18250
+            if defined? RubyVM::InstructionSequence
+              RubyVM::InstructionSequence.compile(<<~RUBY).to_binary
+                def foo(*); ->{ super }; end; def foo(**); ->{ super }; end
+              RUBY
+            end
             false
-          rescue SyntaxError
+          rescue TypeError
             true
           end
-        end
 
-        if has_ruby_bug_22023 && RUBY_DESCRIPTION.include?("+PRISM")
-          module PatchRubyBug22023
-            def compile_file(path, options = nil)
-              compile_file_prism(path, options)
+          has_ruby_bug_22023 = if defined?(RubyVM::InstructionSequence) && RubyVM::InstructionSequence.respond_to?(:compile_file_prism)
+            begin
+              RubyVM::InstructionSequence.compile_file(File.expand_path("../ruby_bug_22023_canary.rb", __FILE__))
+              false
+            rescue SyntaxError
+              true
             end
+          end
 
-            has_ruby_bug_22023_bis = !RubyVM::InstructionSequence.compile_file_prism(
-              File.expand_path("../ruby_bug_22023_canary.rb", __FILE__),
-              {frozen_string_literal: true},
-            ).eval.frozen?
+          if has_ruby_bug_22023 && RUBY_DESCRIPTION.include?("+PRISM")
+            module PatchRubyBug22023
+              def compile_file(path, options = nil)
+                compile_file_prism(path, options)
+              end
 
-            if has_ruby_bug_22023_bis
-              def compile_file_prism(path, options = nil)
-                compile_prism(::File.read(path, encoding: Encoding::UTF_8), path, path, nil, options)
+              has_ruby_bug_22023_bis = !RubyVM::InstructionSequence.compile_file_prism(
+                File.expand_path("../ruby_bug_22023_canary.rb", __FILE__),
+                {frozen_string_literal: true},
+              ).eval.frozen?
+
+              if has_ruby_bug_22023_bis
+                def compile_file_prism(path, options = nil)
+                  compile_prism(::File.read(path, encoding: Encoding::UTF_8), path, path, nil, options)
+                end
+              end
+            end
+            RubyVM::InstructionSequence.singleton_class.prepend(PatchRubyBug22023)
+          end
+
+          if has_ruby_bug_18250
+            def input_to_storage(_, path)
+              iseq = RubyVM::InstructionSequence.compile_file(path, @compile_options)
+              iseq.to_binary
+            rescue TypeError, SyntaxError # Ruby [Bug #18250] & [Bug #22023]
+              UNCOMPILABLE
+            end
+          else
+            def input_to_storage(_, path)
+              RubyVM::InstructionSequence.compile_file(path, @compile_options).to_binary
+            rescue SyntaxError # Ruby [Bug #22023]
+              UNCOMPILABLE
+            end
+          end
+
+          def storage_to_output(binary, _args)
+            iseq = RubyVM::InstructionSequence.load_from_binary(binary)
+            binary.clear
+            iseq
+          rescue RuntimeError => error
+            if error.message == "broken binary format"
+              $stderr.puts("[Bootsnap::CompileCache] warning: rejecting broken binary")
+              nil
+            else
+              raise
+            end
+          end
+
+          def input_to_output(source, path, _kwargs)
+            if @compile_options
+              if source
+                RubyVM::InstructionSequence.compile(
+                  source.force_encoding(Encoding.default_external),
+                  path,
+                  path,
+                  nil,
+                  @compile_options,
+                )
+              else
+                RubyVM::InstructionSequence.compile_file(path, @compile_options)
               end
             end
           end
-          RubyVM::InstructionSequence.singleton_class.prepend(PatchRubyBug22023)
         end
 
-        if has_ruby_bug_18250
-          def input_to_storage(_, path)
-            iseq = RubyVM::InstructionSequence.compile_file(path, @compile_options)
-            iseq.to_binary
-          rescue TypeError, SyntaxError # Ruby [Bug #18250] & [Bug #22023]
-            UNCOMPILABLE
+        DEFAULT = Compiler.new
+        FROZEN_STRING_LITERAL = Compiler.new("-fstr", {frozen_string_literal: true}.freeze)
+        COVERAGE_SUPPORTED = RUBY_VERSION >= "4.0.4"
+
+        @default_compiler = DEFAULT
+        @coverage_support_warning_emitted = false
+
+        def self.fetch(path, cache_dir: ISeq.cache_dir)
+          compiler = compiler_selector&.call(path) || default_compiler
+
+          # Having coverage enabled prevents iseq dumping/loading.
+          if coverage_on?
+            return nil if compiler.equal?(DEFAULT)
+
+            if COVERAGE_SUPPORTED
+              return compiler.input_to_output(nil, path.to_s, nil)
+            elsif !@coverage_support_warning_emitted
+              @coverage_support_warning_emitted = true
+              warn(<<~MSG)
+                Using `Bootsnap.enable_frozen_string_literal` with code coverage enabled is only supported on Ruby 4.0.4+.
+                Files loaded while coverage is on, will have mutable string literals.
+              MSG
+            end
+
+            return nil
+          end
+
+          Bootsnap::CompileCache::Native.fetch(
+            cache_dir,
+            compiler.namespace,
+            path.to_s,
+            compiler,
+            nil,
+          )
+        end
+
+        def self.precompile(path)
+          compiler = compiler_selector&.call(path) || default_compiler
+          Bootsnap::CompileCache::Native.precompile(
+            cache_dir,
+            compiler.namespace,
+            path.to_s,
+            compiler,
+          )
+        end
+
+        if RUBY_VERSION < "3.1."
+          def self.coverage_on?
+            defined?(Coverage) && Coverage.running?
           end
         else
-          def input_to_storage(_, path)
-            RubyVM::InstructionSequence.compile_file(path, @compile_options).to_binary
-          rescue SyntaxError # Ruby [Bug #22023]
-            UNCOMPILABLE
+          def self.coverage_on?
+            defined?(Coverage) && Coverage.state != :idle
           end
         end
 
-        def storage_to_output(binary, _args)
-          iseq = RubyVM::InstructionSequence.load_from_binary(binary)
-          binary.clear
-          iseq
-        rescue RuntimeError => error
-          if error.message == "broken binary format"
-            $stderr.puts("[Bootsnap::CompileCache] warning: rejecting broken binary")
-            nil
-          else
+        module InstructionSequenceMixin
+          def load_iseq(path)
+            Bootsnap::CompileCache::ISeq.fetch(path.to_s)
+          rescue RuntimeError => error
+            if error.message.include?("unmatched platform")
+              puts("unmatched platform for file #{path}")
+            end
             raise
           end
-        end
 
-        def input_to_output(source, path, _kwargs)
-          if @compile_options
-            RubyVM::InstructionSequence.compile(
-              source.force_encoding(Encoding.default_external),
-              path,
-              path,
-              nil,
-              @compile_options,
-            )
+          def compile_option=(hash)
+            super
+            Bootsnap::CompileCache::ISeq.compile_option_updated
           end
         end
-      end
 
-      DEFAULT = Compiler.new
-      FROZEN_STRING_LITERAL = Compiler.new("-fstr", {frozen_string_literal: true}.freeze)
-      COVERAGE_SUPPORTED = RUBY_VERSION >= "4.0.4"
-      @default_compiler = DEFAULT
-      @coverage_support_warning_emitted = false
-
-      def self.fetch(path, cache_dir: ISeq.cache_dir)
-        compiler = compiler_selector&.call(path) || default_compiler
-
-        # Having coverage enabled prevents iseq dumping/loading.
-        if coverage_on?
-          return nil if compiler.equal?(DEFAULT)
-
-          if COVERAGE_SUPPORTED
-            return compiler.input_to_output(File.read(path.to_s), path.to_s, nil)
-          elsif !@coverage_support_warning_emitted
-            @coverage_support_warning_emitted = true
-            warn(<<~MSG)
-              Using `Bootsnap.enable_frozen_string_literal` with code coverage enabled is only supported on Ruby 4.0.4+.
-              Files loaded while coverage is on, will have mutable string literals.
-            MSG
-          end
-
-          return nil
+        def self.compile_option_updated
+          option = RubyVM::InstructionSequence.compile_option
+          crc = Zlib.crc32(option.inspect)
+          Bootsnap::CompileCache::Native.compile_option_crc32 = crc
+          FROZEN_STRING_LITERAL.update_options
         end
+        compile_option_updated if supported?
 
-        Bootsnap::CompileCache::Native.fetch(
-          cache_dir,
-          compiler.namespace,
-          path.to_s,
-          compiler,
-          nil,
-        )
-      end
+        def self.install!(cache_dir)
+          Bootsnap::CompileCache::ISeq.cache_dir = cache_dir
 
-      def self.precompile(path)
-        compiler = compiler_selector&.call(path) || default_compiler
-        Bootsnap::CompileCache::Native.precompile(
-          cache_dir,
-          compiler.namespace,
-          path.to_s,
-          compiler,
-        )
-      end
+          return unless supported?
 
-      if RUBY_VERSION < "3.1."
-        def self.coverage_on?
-          defined?(Coverage) && Coverage.running?
+          Bootsnap::CompileCache::ISeq.compile_option_updated
+
+          class << RubyVM::InstructionSequence
+            prepend(InstructionSequenceMixin)
+          end
         end
       else
-        def self.coverage_on?
-          defined?(Coverage) && Coverage.state != :idle
-        end
-      end
-
-      module InstructionSequenceMixin
-        def load_iseq(path)
-          Bootsnap::CompileCache::ISeq.fetch(path.to_s)
-        rescue RuntimeError => error
-          if error.message.include?("unmatched platform")
-            puts("unmatched platform for file #{path}")
-          end
-          raise
+        def self.install!(...)
+          # noop
         end
 
-        def compile_option=(hash)
-          super
-          Bootsnap::CompileCache::ISeq.compile_option_updated
-        end
-      end
-
-      def self.compile_option_updated
-        option = RubyVM::InstructionSequence.compile_option
-        crc = Zlib.crc32(option.inspect)
-        Bootsnap::CompileCache::Native.compile_option_crc32 = crc
-      end
-      compile_option_updated if supported?
-
-      def self.install!(cache_dir)
-        Bootsnap::CompileCache::ISeq.cache_dir = cache_dir
-
-        return unless supported?
-
-        Bootsnap::CompileCache::ISeq.compile_option_updated
-
-        class << RubyVM::InstructionSequence
-          prepend(InstructionSequenceMixin)
+        def self.precompile(...)
+          # noop
         end
       end
     end

--- a/test/compile_cache_key_format_test.rb
+++ b/test/compile_cache_key_format_test.rb
@@ -35,6 +35,19 @@ class CompileCacheKeyFormatTest < Minitest::Test
     RubyVM::InstructionSequence.compile_option = {tailcall_optimization: false}
   end
 
+  def test_key_compile_option_custom_compiler
+    Bootsnap::CompileCache::ISeq.default_compiler = Bootsnap::CompileCache::ISeq::FROZEN_STRING_LITERAL
+    k1 = cache_key_for_file(FILE)
+    k2 = cache_key_for_file(FILE)
+    RubyVM::InstructionSequence.compile_option = {tailcall_optimization: true}
+    k3 = cache_key_for_file(FILE)
+    assert_equal(k1[R[:ruby_version_digest]], k2[R[:ruby_version_digest]])
+    refute_equal(k1[R[:ruby_version_digest]], k3[R[:ruby_version_digest]])
+  ensure
+    Bootsnap::CompileCache::ISeq.default_compiler = Bootsnap::CompileCache::ISeq::DEFAULT
+    RubyVM::InstructionSequence.compile_option = {tailcall_optimization: false}
+  end
+
   def test_key_ruby_version_digest
     Bootsnap::CompileCache::ISeq.compile_option_updated
 


### PR DESCRIPTION
When it changes, we need to update our custom compilers options too.