### PR TITLE
Only load config file is directed to by `.setup`

### DIFF
--- a/lib/bootsnap.rb
+++ b/lib/bootsnap.rb
@@ -43,13 +43,6 @@ module Bootsnap
       @instrumentation.call(event, path)
     end
 
-    def load_config
-      config_path = File.expand_path(ENV["BOOTSNAP_CONFIG"] || "config/bootsnap.rb")
-      if File.exist?(config_path)
-        require(config_path)
-      end
-    end
-
     def setup(
       cache_dir:,
       development_mode: true,
@@ -59,7 +52,8 @@ module Bootsnap
       revalidation: false,
       compile_cache_iseq: true,
       compile_cache_yaml: true,
-      compile_cache_json: (compile_cache_json_unset = true)
+      compile_cache_json: (compile_cache_json_unset = true),
+      config_path: nil
     )
       unless compile_cache_json_unset
         warn("Bootsnap.setup `compile_cache_json` argument is deprecated and has no effect")
@@ -84,7 +78,16 @@ module Bootsnap
         revalidation: revalidation,
       )
 
-      load_config
+      load_config(config_path)
+    end
+
+    def load_config(config_path)
+      if config_path
+        config_path = File.expand_path(config_path)
+        if File.exist?(config_path)
+          require(config_path)
+        end
+      end
     end
 
     def enable_frozen_string_literal(app_only: false)
@@ -150,6 +153,7 @@ module Bootsnap
           readonly: bool_env("BOOTSNAP_READONLY"),
           revalidation: bool_env("BOOTSNAP_REVALIDATE"),
           ignore_directories: ignore_directories,
+          config_path: ENV["BOOTSNAP_CONFIG"] || "config/bootsnap.rb",
         )
 
         if ENV["BOOTSNAP_LOG"]

--- a/lib/bootsnap/cli.rb
+++ b/lib/bootsnap/cli.rb
@@ -43,7 +43,7 @@ module Bootsnap
           yaml: yaml,
           revalidation: true,
         )
-        Bootsnap.load_config
+        Bootsnap.load_config(ENV["BOOTSNAP_CONFIG"] || "config/bootsnap.rb")
 
         @work_pool = WorkerPool.create(size: jobs, jobs: {
           ruby: method(:precompile_ruby),

--- a/test/setup_test.rb
+++ b/test/setup_test.rb
@@ -24,6 +24,7 @@ module Bootsnap
         ignore_directories: nil,
         readonly: false,
         revalidation: false,
+        config_path: "config/bootsnap.rb",
       )
 
       Bootsnap.default_setup
@@ -41,6 +42,7 @@ module Bootsnap
         ignore_directories: nil,
         readonly: false,
         revalidation: false,
+        config_path: "config/bootsnap.rb",
       )
 
       Bootsnap.default_setup
@@ -58,6 +60,7 @@ module Bootsnap
         ignore_directories: nil,
         readonly: false,
         revalidation: false,
+        config_path: "config/bootsnap.rb",
       )
 
       Bootsnap.default_setup
@@ -75,6 +78,7 @@ module Bootsnap
         ignore_directories: nil,
         readonly: false,
         revalidation: false,
+        config_path: "config/bootsnap.rb",
       )
 
       Bootsnap.default_setup
@@ -99,6 +103,7 @@ module Bootsnap
         ignore_directories: nil,
         readonly: false,
         revalidation: false,
+        config_path: "config/bootsnap.rb",
       )
       Bootsnap.expects(:logger=).with($stderr.method(:puts))
 
@@ -117,6 +122,7 @@ module Bootsnap
         ignore_directories: %w[foo bar],
         readonly: false,
         revalidation: false,
+        config_path: "config/bootsnap.rb",
       )
 
       Bootsnap.default_setup
@@ -134,6 +140,7 @@ module Bootsnap
         ignore_directories: nil,
         readonly: true,
         revalidation: false,
+        config_path: "config/bootsnap.rb",
       )
 
       Bootsnap.default_setup
@@ -149,6 +156,7 @@ module Bootsnap
         ignore_directories: nil,
         readonly: false,
         revalidation: false,
+        config_path: "config/bootsnap.rb",
       )
 
       Bootsnap.default_setup


### PR DESCRIPTION
I didn't know homebrew does use Bootsnap, but turns out they recently upgraded to 1.24.x, and it's a problem because if you invoke brew commands from a directory with `config/bootsnap.rb` config file, homebrew end up loading it as its own.

It's particularly problematic because homebrew doesn't have bundler loaded, so it generally fails with an error:

```
$ brew upgrade ...
/opt/homebrew/Library/Homebrew/vendor/portable-ruby/current/lib/ruby/gems/4.0.0/gems/bootsnap-1.24.3/lib/bootsnap.rb:92:in 'Bootsnap.enable_frozen_string_literal': uninitialized constant #<Class:Bootsnap>::Bundler (NameError)
	from /Users/..../config/bootsnap.rb:1:in '<main>'
  ...
	from /opt/homebrew/Library/Homebrew/vendor/portable-ruby/current/lib/ruby/gems/4.0.0/gems/bootsnap-1.24.3/lib/bootsnap.rb:49:in 'Bootsnap.load_config'
	from /opt/homebrew/Library/Homebrew/vendor/portable-ruby/current/lib/ruby/gems/4.0.0/gems/bootsnap-1.24.3/lib/bootsnap.rb:87:in 'Bootsnap.setup'
	from /opt/homebrew/Library/Homebrew/startup/bootsnap.rb:49:in 'Homebrew::Bootsnap.load!'
	from /opt/homebrew/Library/Homebrew/startup/bootsnap.rb:75:in '<top (required)>'
	from /opt/homebrew/Library/Homebrew/startup.rb:8:in 'Kernel#require_relative'
	from /opt/homebrew/Library/Homebrew/startup.rb:8:in '<top (required)>'
	from /opt/homebrew/Library/Homebrew/global.rb:4:in 'Kernel#require_relative'
	from /opt/homebrew/Library/Homebrew/global.rb:4:in '<top (required)>'
	from /opt/homebrew/Library/Homebrew/brew.rb:18:in 'Kernel#require_relative'
	from /opt/homebrew/Library/Homebrew/brew.rb:18:in '<main>'

```