### PR TITLE
ci: add permissions: contents: read to ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,9 @@ on:
   schedule:
     - cron:  '45 4 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   platforms:
     strategy:


### PR DESCRIPTION
Adds an explicit workflow-level `permissions:` block to `ci.yaml`.

Scope set: `contents: read` (the minimum for checkout + the read-only steps this workflow runs).

Checklist:

- [x] Workflow does not push commits, create releases, or write issues/PRs
- [x] No `pull_request_target` trigger; this is a regular `push`/`pull_request` workflow
- [x] No `actions/cache@v3+` save path (would need `actions: write`)
- [x] YAML re-parses with `yaml.safe_load`
- [x] Matches the pattern recommended in GitHub's [token hardening docs](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token)

This is one of the lowest-effort items on the OpenSSF Scorecard Token-Permissions check, and one of the cheaper defenses against incidents like tj-actions/changed-files compromise in March 2025 (CVE-2025-30066).
