### PR TITLE
Check for [Bug #22023] by checking Ruby version rather than a canary

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -64,6 +64,9 @@ Naming/VariableNumber:
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 
+Layout/CaseIndentation:
+  EnforcedStyle: end
+
 Layout/EndAlignment:
   EnforcedStyleAlignWith: start_of_line
 
@@ -122,6 +125,9 @@ Security/YAMLLoad:
 
 # allow String.new to create mutable strings
 Style/EmptyLiteral:
+  Enabled: false
+
+Style/PerlBackrefs:
   Enabled: false
 
 Style/EmptyMethod:

--- a/lib/bootsnap/compile_cache/iseq.rb
+++ b/lib/bootsnap/compile_cache/iseq.rb
@@ -48,13 +48,15 @@ module Bootsnap
             true
           end
 
-          has_ruby_bug_22023 = if defined?(RubyVM::InstructionSequence) && RubyVM::InstructionSequence.respond_to?(:compile_file_prism)
-            begin
-              RubyVM::InstructionSequence.compile_file(File.expand_path("../ruby_bug_22023_canary.rb", __FILE__))
-              false
-            rescue SyntaxError
-              true
-            end
+          has_ruby_bug_22023 = case RUBY_VERSION
+          when /^3\.3\./
+            true
+          when /^3\.4\.(\d+)/
+            $1.to_i < 10
+          when /^4\.0\.(\d+)/
+            $1.to_i < 4
+          else
+            false
           end
 
           if has_ruby_bug_22023 && RUBY_DESCRIPTION.include?("+PRISM")

--- a/lib/bootsnap/compile_cache/ruby_bug_22023_canary.rb
+++ b/lib/bootsnap/compile_cache/ruby_bug_22023_canary.rb
@@ -1,7 +1,1 @@
-_f = -> {
-  case foo
-  in [one, "a" | "b" => two]
-    puts "#{one} - #{two}"
-  end
-}
 _ = "test"


### PR DESCRIPTION
A canary was useful when it was unclear if and when the bug would be fixed or backported. Now that the fix made it to Ruby 4.0.4 and has been backported to Ruby 3_4 branch and will be released with Ruby 3.4.10 we can just check versions.

The problem with the canary is that it rely on specific `parse.y` bug that may not be present on all Ruby versions with [Bug #22023].

Fix: https://github.com/rails/bootsnap/issues/555