### PR TITLE
Fix `CompileCache::YAML` cache options mutation & `symbolize_{keys,names}`

### DIFF
--- a/lib/bootsnap/compile_cache/yaml.rb
+++ b/lib/bootsnap/compile_cache/yaml.rb
@@ -135,6 +135,14 @@ module Bootsnap
 
           NoTagsVisitor.new(scanner, loader).visit(ast)
         end
+
+        def msgpack_unpacker_options(kwargs)
+          return kwargs unless kwargs&.key?(:symbolize_names)
+
+          kwargs = kwargs.dup
+          kwargs[:symbolize_keys] = kwargs.delete(:symbolize_names)
+          kwargs
+        end
       end
 
       module Psych4
@@ -164,11 +172,9 @@ module Bootsnap
           end
 
           def storage_to_output(data, kwargs)
-            if kwargs&.key?(:symbolize_names)
-              kwargs[:symbolize_keys] = kwargs.delete(:symbolize_names)
-            end
-
-            unpacker = CompileCache::YAML.msgpack_factory.unpacker(kwargs)
+            unpacker = CompileCache::YAML.msgpack_factory.unpacker(
+              CompileCache::YAML.msgpack_unpacker_options(kwargs),
+            )
             unpacker.feed(data)
             _safe_loaded = unpacker.unpack
             result = unpacker.unpack
@@ -202,11 +208,9 @@ module Bootsnap
           end
 
           def storage_to_output(data, kwargs)
-            if kwargs&.key?(:symbolize_names)
-              kwargs[:symbolize_keys] = kwargs.delete(:symbolize_names)
-            end
-
-            unpacker = CompileCache::YAML.msgpack_factory.unpacker(kwargs)
+            unpacker = CompileCache::YAML.msgpack_factory.unpacker(
+              CompileCache::YAML.msgpack_unpacker_options(kwargs),
+            )
             unpacker.feed(data)
             safe_loaded = unpacker.unpack
             if safe_loaded
@@ -282,10 +286,9 @@ module Bootsnap
         end
 
         def storage_to_output(data, kwargs)
-          if kwargs&.key?(:symbolize_names)
-            kwargs[:symbolize_keys] = kwargs.delete(:symbolize_names)
-          end
-          unpacker = CompileCache::YAML.msgpack_factory.unpacker(kwargs)
+          unpacker = CompileCache::YAML.msgpack_factory.unpacker(
+            CompileCache::YAML.msgpack_unpacker_options(kwargs),
+          )
           unpacker.feed(data)
           _safe_loaded = unpacker.unpack
           unpacker.unpack

--- a/test/compile_cache/yaml_test.rb
+++ b/test/compile_cache/yaml_test.rb
@@ -152,6 +152,20 @@ class CompileCacheYAMLTest < Minitest::Test
       }
       assert_equal expected, document
     end
+
+    def test_load_file_symbolize_names_after_unsafe_cache
+      skip unless ::Bootsnap::CompileCache::YAML.supported_options.include?(:symbolize_names)
+
+      Help.set_file("a.yml", "---\nfoo: bar", 100)
+
+      kwargs = {symbolize_names: true}
+      FakeYaml.unsafe_load_file("a.yml", **kwargs)
+
+      2.times do
+        assert_equal({foo: "bar"}, FakeYaml.load_file("a.yml", **kwargs))
+        assert_equal({symbolize_names: true}, kwargs)
+      end
+    end
   else
     def test_yaml_input_to_output
       document = ::Bootsnap::CompileCache::YAML::Psych3.input_to_output(<<~YAML, "file.yml", {})


### PR DESCRIPTION
during cache miss (when an entry for a YAML file exists, but is not usable e.g. due to safety mismatch) the `storage_to_output` is hit; it mutates `kwargs`, replacing `symbolize_names` with `symbolize_keys`, which is not supported by `psych`.

```shell
1) Error:
CompileCacheYAMLTest#test_load_file_symbolize_names_after_unsafe_cache:
ArgumentError: unknown keyword: :symbolize_keys
    ~/.asdf/installs/ruby/4.0.5/lib/ruby/4.0.0/psych.rb:369:in 'Psych.load'
    lib/bootsnap/compile_cache/yaml.rb:220:in 'Bootsnap::CompileCache::YAML::Psych4::SafeLoad#input_to_output'
    lib/bootsnap/compile_cache/yaml.rb:235:in 'Bootsnap::CompileCache::Native.fetch'
    lib/bootsnap/compile_cache/yaml.rb:235:in 'Bootsnap::CompileCache::YAML::Psych4::Patch#load_file'
    test/compile_cache/yaml_test.rb:165:in 'block in CompileCacheYAMLTest#test_load_file_symbolize_names_after_unsafe_cache'
    test/compile_cache/yaml_test.rb:164:in 'Integer#times'
    test/compile_cache/yaml_test.rb:164:in 'CompileCacheYAMLTest#test_load_file_symbolize_names_after_unsafe_cache'
```